### PR TITLE
[Alang-13] 멘토 대시보드 페이지 UI 퍼블리싱

### DIFF
--- a/apps/service/package.json
+++ b/apps/service/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.6",
+    "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",

--- a/apps/service/src/pages/mentor/components/mentee-requests.tsx
+++ b/apps/service/src/pages/mentor/components/mentee-requests.tsx
@@ -1,0 +1,130 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/shared/ui/avatar";
+import { Badge } from "@/shared/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/shared/ui/pagination";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/shared/ui/table";
+
+export default function MenteeRequests() {
+  // 실제 구현에서는 API에서 멘티 신청 목록을 가져올 것입니다
+  const menteeRequests = [
+    {
+      id: 1,
+      date: "2023-05-10 14:00",
+      mentee: {
+        name: "John Doe",
+        avatar: "/placeholder.svg?height=40&width=40",
+      },
+      inquiry: "React 상태 관리에 대해 질문이 있습니다",
+      status: "대기중",
+    },
+    {
+      id: 2,
+      date: "2023-05-12 15:30",
+      mentee: {
+        name: "Jane Doe",
+        avatar: "/placeholder.svg?height=40&width=40",
+      },
+      inquiry: "프론트엔드 개발자 커리어 상담",
+      status: "승인",
+    },
+    {
+      id: 3,
+      date: "2023-05-15 10:00",
+      mentee: {
+        name: "Kim Smith",
+        avatar: "/placeholder.svg?height=40&width=40",
+      },
+      inquiry: "Next.js 프로젝트 구조에 대한 조언",
+      status: "대기중",
+    },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-xl">신청한 멘티관리</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-md p-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>신청한 날짜&시간</TableHead>
+                <TableHead>멘티</TableHead>
+                <TableHead>문의내용</TableHead>
+                <TableHead className="text-center">상태</TableHead>
+                <TableHead className="text-center">관리</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {menteeRequests.map((request) => (
+                <TableRow key={request.id}>
+                  <TableCell>{request.date}</TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <Avatar className="h-8 w-8">
+                        <AvatarImage
+                          src={request.mentee.avatar}
+                          alt={request.mentee.name}
+                        />
+                        <AvatarFallback>
+                          {request.mentee.name.substring(0, 2)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <span>{request.mentee.name}</span>
+                    </div>
+                  </TableCell>
+                  <TableCell>{request.inquiry}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        request.status === "승인" ? "outline" : "secondary"
+                      }
+                    >
+                      {request.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Badge variant="outline" className="cursor-pointer">
+                      관리
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+          <div className="flex items-center justify-center py-4">
+            <Pagination>
+              <PaginationContent>
+                <PaginationItem>
+                  <PaginationPrevious href="#" />
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationLink href="#">1</PaginationLink>
+                </PaginationItem>
+                <PaginationItem>
+                  <PaginationNext href="#" />
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/service/src/pages/mentor/components/mentor-info.tsx
+++ b/apps/service/src/pages/mentor/components/mentor-info.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/shared/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
+import { Table, TableBody, TableCell, TableRow } from "@/shared/ui/table";
+
+export default function MentorInfo() {
+  const mentorInfo = {
+    position: "소프트웨어 개발자",
+    experience: "5년",
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-xl">멘토 관리</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col md:flex-row gap-4">
+          <div className="flex-1 relative py-2">
+            <div className="absolute top-0 right-0">
+              <Button variant="outline">수정</Button>
+            </div>
+            <h3 className="text-lg font-medium mb-2">멘토정보</h3>
+            <div className="rounded-md p-4">
+              <Table>
+                <TableBody>
+                  <TableRow>
+                    <TableCell className="font-semibold w-24">직무</TableCell>
+                    <TableCell>{mentorInfo.position}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell className="font-semibold">경력</TableCell>
+                    <TableCell>{mentorInfo.experience}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/service/src/pages/mentor/components/mentoring-posts.tsx
+++ b/apps/service/src/pages/mentor/components/mentoring-posts.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/shared/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/shared/ui/table";
+
+export default function MentoringPosts() {
+  // 실제 구현에서는 API에서 멘토링 글 목록을 가져올 것입니다
+  const mentoringPosts = [
+    {
+      id: 1,
+      registrationDate: "2023-03-15",
+      content: "프론트엔드 개발 멘토링",
+    },
+    {
+      id: 2,
+      registrationDate: "2023-04-20",
+      content: "React 프로젝트 코드 리뷰",
+    },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-xl">등록한 멘토링 글</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-md p-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[150px]">등록일</TableHead>
+                <TableHead>멘토링 내용</TableHead>
+                <TableHead className="text-right w-[150px]">관리</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {mentoringPosts.map((post) => (
+                <TableRow key={post.id}>
+                  <TableCell>{post.registrationDate}</TableCell>
+                  <TableCell>{post.content}</TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button size="sm" variant="outline">
+                        수정
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="text-destructive"
+                      >
+                        삭제
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/service/src/pages/mentor/dashboard.page.tsx
+++ b/apps/service/src/pages/mentor/dashboard.page.tsx
@@ -7,14 +7,14 @@ import { Typography } from "@/shared/ui/typography";
 export function MentorDashboardPage() {
   return (
     <PageLayout>
-      <div className="container mx-auto py-6 space-y-8">
+      <div className="container mx-auto py-6 space-y-8 px-4">
         <Typography.H2>멘토 대시보드</Typography.H2>
 
-        <div className="container mx-auto space-y-8">
+        <section className="container mx-auto space-y-8">
           <MentorInfo />
           <MentoringPosts />
           <MenteeRequests />
-        </div>
+        </section>
       </div>
     </PageLayout>
   );

--- a/apps/service/src/pages/mentor/dashboard.page.tsx
+++ b/apps/service/src/pages/mentor/dashboard.page.tsx
@@ -1,31 +1,21 @@
+import MenteeRequests from "@/pages/mentor/components/mentee-requests";
+import MentorInfo from "@/pages/mentor/components/mentor-info";
+import MentoringPosts from "@/pages/mentor/components/mentoring-posts";
+import { PageLayout } from "@/shared/layouts/page-layout";
+import { Typography } from "@/shared/ui/typography";
+
 export function MentorDashboardPage() {
   return (
-    <>
-      <h1>DeMentor: Service</h1>
-      <h2>멘토 대시보드</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        <div className="bg-white p-6 rounded-lg shadow">
-          <h3 className="text-lg font-bold mb-4">현재 수업</h3>
-          <div className="space-y-2">
-            <p>진행중인 수업: 2개</p>
-            <p>예정된 수업: 3개</p>
-          </div>
-        </div>
-        <div className="bg-white p-6 rounded-lg shadow">
-          <h3 className="text-lg font-bold mb-4">학생 현황</h3>
-          <div className="space-y-2">
-            <p>전체 학생: 15명</p>
-            <p>활성 학생: 12명</p>
-          </div>
-        </div>
-        <div className="bg-white p-6 rounded-lg shadow">
-          <h3 className="text-lg font-bold mb-4">수업 요청</h3>
-          <div className="space-y-2">
-            <p>새로운 요청: 3개</p>
-            <p>대기중인 요청: 2개</p>
-          </div>
+    <PageLayout>
+      <div className="container mx-auto py-6 space-y-8">
+        <Typography.H2>멘토 대시보드</Typography.H2>
+
+        <div className="container mx-auto space-y-8">
+          <MentorInfo />
+          <MentoringPosts />
+          <MenteeRequests />
         </div>
       </div>
-    </>
+    </PageLayout>
   );
 }

--- a/apps/service/src/shared/ui/scroll-area.tsx
+++ b/apps/service/src/shared/ui/scroll-area.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/shared/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/apps/service/src/widgets/auth/signup-form.tsx
+++ b/apps/service/src/widgets/auth/signup-form.tsx
@@ -20,11 +20,11 @@ const signupFormSchema = z
   .object({
     email: z
       .string()
-      .email({
-        message: "이메일 형식이 올바르지 않습니다.",
-      })
       .nonempty({
         message: "이메일을 입력해주세요.",
+      })
+      .email({
+        message: "이메일 형식이 올바르지 않습니다.",
       }),
     password: z
       .string()

--- a/apps/service/test/widgets/auth/signup-form.test.tsx
+++ b/apps/service/test/widgets/auth/signup-form.test.tsx
@@ -1,6 +1,6 @@
 import { DuplicateError } from "@/app/errors/duplicate.error";
 import { SignupForm } from "@/widgets/auth/signup-form";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRoutesStub } from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -69,9 +69,7 @@ describe("SignupForm", () => {
       fireEvent.change(nameInput, { target: { value: "test" } });
       fireEvent.change(nameInput, { target: { value: "" } });
 
-      waitFor(() => {
-        expect(screen.getByText("이름을 입력해주세요."));
-      });
+      expect(await screen.findByText("이름을 입력해주세요."));
     });
 
     test("닉네임 필드에 이미 존재하는 닉네임을 입력한 후에 중복 확인 버튼을 누르면 '이미 사용중인 닉네임입니다.' 메시지가 표시된다.", async () => {
@@ -120,12 +118,12 @@ describe("SignupForm", () => {
       // act
 
       fireEvent.change(emailInput, { target: { value: "test@test.com" } });
+
       fireEvent.change(emailInput, { target: { value: "" } });
 
       // assert
-      waitFor(() => {
-        expect(screen.getByText("이메일을 입력해주세요."));
-      });
+      expect(emailInput.value).toBe("");
+      expect(await screen.findByText("이메일을 입력해주세요."));
     });
 
     test("이메일 필드에 이미 존재하는 이메일을 입력한 후에 중복 확인 버튼을 누르면 '이미 사용중인 이메일입니다.' 메시지가 표시된다.", async () => {
@@ -177,9 +175,7 @@ describe("SignupForm", () => {
       fireEvent.change(passwordInput, { target: { value: "" } });
 
       // assert
-      waitFor(() => {
-        expect(screen.getByText("비밀번호를 입력해주세요."));
-      });
+      expect(await screen.findByText("비밀번호를 입력해주세요."));
     });
 
     test.each`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.6
         version: 1.1.6(@types/react-dom@19.0.4)(@types/react@19.0.12)(react-dom@19.0.0)(react@19.0.0)
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react-dom@19.0.4)(@types/react@19.0.12)(react-dom@19.0.0)(react@19.0.0)
       '@radix-ui/react-select':
         specifier: ^2.1.6
         version: 2.1.6(@types/react-dom@19.0.4)(@types/react@19.0.12)(react-dom@19.0.0)(react@19.0.0)
@@ -1794,6 +1797,34 @@ packages:
       '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4)(@types/react@19.0.12)(react-dom@19.0.0)(react@19.0.0)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.12)(react@19.0.0)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@types/react': 19.0.12
+      '@types/react-dom': 19.0.4(@types/react@19.0.12)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    dev: false
+
+  /@radix-ui/react-scroll-area@1.2.3(@types/react-dom@19.0.4)(@types/react@19.0.12)(react-dom@19.0.0)(react@19.0.0):
+    resolution: {integrity: sha512-l7+NNBfBYYJa9tNqVcP2AGvxdE3lmE6kFTBXdvHgUaZuy+4wGCL1Cl2AfaR7RKyimj7lZURGLwFO59k4eBnDJQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.4)(@types/react@19.0.12)(react-dom@19.0.0)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4)(@types/react@19.0.12)(react-dom@19.0.0)(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.12)(react@19.0.0)
       '@types/react': 19.0.12
       '@types/react-dom': 19.0.4(@types/react@19.0.12)
       react: 19.0.0


### PR DESCRIPTION
## 요약

멘토 대시보드 페이지에 대한 UI 퍼블리싱을 진행합니다.

## 작업 내용

- [config: shadcn/ui 추가](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/7/commits/defaf42b88c09a13acac59f180c1b4c433ab3edc)
- [feat: 멘토 대시보드 페이지 UI 퍼블리싱](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/7/commits/e4f8248dcd15f0c4075fe26da5dd58cf966f932e)


## 스크린샷

| Desktop | Mobile |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/915a612f-21c0-40bb-ad45-22fa5acfcd19) | ![image](https://github.com/user-attachments/assets/7ed35799-449f-4bde-8cc5-497ecf62f064) |

