### PR TITLE
[Alang-4]  디멘터 api fetch client를 제공하는 @repo/api 패키지 작성

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
       "mode": "auto"
     }
   ],
-  "cSpell.words": ["mentee"]
+  "cSpell.words": ["applyments", "dementor", "mentee"]
 }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@react-router/node": "^7.4.0",
     "@react-router/serve": "^7.4.0",
+    "@repo/api": "workspace:^",
     "@repo/design-system": "workspace:^",
     "@repo/ui": "workspace:^",
     "@repo/utils": "workspace:^",
@@ -31,8 +32,8 @@
     "tw-animate-css": "^1.2.4"
   },
   "devDependencies": {
-    "@repo/eslint-config": "workspace:*",
     "@react-router/dev": "^7.4.0",
+    "@repo/eslint-config": "workspace:*",
     "@testing-library/react": "^16.2.0",
     "@types/node": "^22.13.14",
     "@types/react": "^19.0.10",

--- a/apps/service/package.json
+++ b/apps/service/package.json
@@ -16,6 +16,7 @@
     "@hookform/resolvers": "^4.1.3",
     "@react-router/node": "^7.4.0",
     "@react-router/serve": "^7.4.0",
+    "@repo/api": "workspace:^",
     "@repo/design-system": "workspace:*",
     "@repo/ui": "workspace:*",
     "@repo/utils": "workspace:^",
@@ -33,8 +34,8 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@repo/eslint-config": "workspace:*",
     "@react-router/dev": "^7.4.0",
+    "@repo/eslint-config": "workspace:*",
     "@tailwindcss/postcss": "^4.0.12",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",

--- a/packages/api/eslint.config.mjs
+++ b/packages/api/eslint.config.mjs
@@ -1,0 +1,9 @@
+import eslintConfig from "../eslint-config/index.mjs";
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...eslintConfig,
+  {
+    ignores: ["dist/**/*"],
+  },
+];

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@repo/api",
+  "version": "1.0.0",
+  "private": true,
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "scripts": {
+    "build": "vite build",
+    "build:dev": "vite build --watch",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ts-custom-error": "^3.3.1"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^22.13.14",
+    "typescript": "^5.8.2",
+    "vite": "^6.2.3",
+    "vite-plugin-dts": "^4.5.3"
+  }
+}

--- a/packages/api/src/.env
+++ b/packages/api/src/.env
@@ -1,0 +1,2 @@
+
+VITE_API_BASE_URL=https://api.dementor.site

--- a/packages/api/src/enums/enums.ts
+++ b/packages/api/src/enums/enums.ts
@@ -1,0 +1,35 @@
+export enum DateOfWeek {
+  SUNDAY = "Sunday",
+  MONDAY = "Monday",
+  TUESDAY = "Tuesday",
+  WEDNESDAY = "Wednesday",
+  THURSDAY = "Thursday",
+  FRIDAY = "Friday",
+  SATURDAY = "Saturday",
+}
+
+export enum ApplyStatus {
+  PENDING = "PENDING",
+  APPROVED = "APPROVED",
+  REJECTED = "REJECTED",
+}
+
+export enum ImageType {
+  NORMAL = "NORMAL",
+  MARKDOWN_SELF_INTRODUCTION = "MARKDOWN_SELF_INTRODUCTION",
+  MARKDOWN_RECOMMENDATION = "MARKDOWN_RECOMMENDATION",
+}
+
+export enum ChatRoomType {
+  MENTORING = "MENTORING_CHAT",
+  ADMIN = "ADMIN_CHAT",
+}
+
+export enum MessageType {
+  MESSAGE = "MESSAGE",
+}
+
+export enum MessageSenderType {
+  MEMBER = "MEMBER",
+  ADMIN = "ADMIN",
+}

--- a/packages/api/src/enums/index.ts
+++ b/packages/api/src/enums/index.ts
@@ -1,0 +1,1 @@
+export * from "./enums";

--- a/packages/api/src/env.d.ts
+++ b/packages/api/src/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/api/src/errors/index.ts
+++ b/packages/api/src/errors/index.ts
@@ -1,0 +1,1 @@
+export * from "./service-error";

--- a/packages/api/src/errors/service-error.ts
+++ b/packages/api/src/errors/service-error.ts
@@ -1,0 +1,142 @@
+import { HTTPError } from "../utils/api-fetcher/HTTPError";
+
+export class ServiceError extends Error {
+  readonly code: number | string;
+
+  constructor(code: number | string, message: string) {
+    super(message);
+    this.code = code;
+  }
+
+  static byHTTPError(error: HTTPError) {
+    return ServiceError.byCode(error.code, error.message);
+  }
+
+  static byCode(code: string | number, message: string) {
+    const codeNumber = Number(code);
+    switch (codeNumber) {
+      case 400:
+        return ServiceError.badRequest(message);
+      case 401:
+        return ServiceError.unauthorized(message);
+      case 403:
+        return ServiceError.forbidden(message);
+      case 404:
+        return ServiceError.notFound(message);
+      case 409:
+        return ServiceError.conflict(message);
+      case 500:
+        return ServiceError.internalServerError(message);
+      default:
+        console.error(`Unknown error code: ${code}`);
+        return new ServiceError(code, message);
+    }
+  }
+
+  static badRequest(message: string) {
+    return new BadRequestError(message);
+  }
+
+  static unauthorized(message: string) {
+    return new UnauthorizedError(message);
+  }
+
+  static forbidden(message: string) {
+    return new ForbiddenError(message);
+  }
+
+  static notFound(message: string) {
+    return new NotFoundError(message);
+  }
+
+  static conflict(message: string) {
+    return new ConflictError(message);
+  }
+
+  static internalServerError(message: string) {
+    return new InternalServerError(message);
+  }
+}
+
+export class BadRequestError extends ServiceError {
+  constructor(message: string) {
+    super(400, message);
+  }
+}
+
+export class UnauthorizedError extends ServiceError {
+  constructor(message: string) {
+    super(401, message);
+  }
+}
+
+export class ForbiddenError extends ServiceError {
+  constructor(message: string) {
+    super(403, message);
+  }
+}
+
+export class NotFoundError extends ServiceError {
+  constructor(message: string) {
+    super(404, message);
+  }
+}
+
+export class ConflictError extends ServiceError {
+  constructor(message: string) {
+    super(409, message);
+  }
+}
+
+export class InternalServerError extends ServiceError {
+  constructor(message: string) {
+    super(500, message);
+  }
+}
+
+export class FieldsError extends ServiceError {
+  readonly fields: { field: string; message: string }[];
+
+  constructor(fields: { field: string; message: string }[], message: string) {
+    super(400, message);
+    this.fields = fields;
+  }
+
+  static isFieldsErrorBody(body: unknown): body is {
+    fields: { field: string; message: string }[];
+    message: string;
+  } {
+    return typeof body === "object" && body !== null && "fields" in body;
+  }
+}
+
+export class ConflictingAppointmentError extends ServiceError {
+  readonly conflicts: {
+    date: string;
+    timePattern: number[];
+  }[];
+
+  constructor(
+    conflicts: { date: string; timePattern: number[] }[],
+    message: string
+  ) {
+    super(409, message);
+    this.conflicts = conflicts;
+  }
+
+  static isConflictingAppointmentBody(body: unknown): body is {
+    data: {
+      conflictingAppointments: { date: string; timePattern: number[] }[];
+    };
+    message: string;
+  } {
+    return (
+      typeof body === "object" &&
+      body !== null &&
+      "data" in body &&
+      typeof body.data === "object" &&
+      body.data !== null &&
+      "conflictingAppointments" in body.data
+    );
+  }
+}

--- a/packages/api/src/fetchers/admin/fetchers.ts
+++ b/packages/api/src/fetchers/admin/fetchers.ts
@@ -1,0 +1,135 @@
+import { generateServiceFetcher } from "@/fetchers/generate-service-fetcher";
+import {
+  MentorApplicationDetailResponse,
+  ServerSuccessResponse,
+} from "@/schemas";
+
+export const login = generateServiceFetcher<
+  void,
+  void,
+  { email: string; password: string },
+  null
+>({
+  endpoint: "/api/admin/login",
+  method: "POST",
+});
+
+export const logout = generateServiceFetcher<
+  void,
+  void,
+  void,
+  { message: string }
+>({
+  endpoint: "/api/admin/logout",
+  method: "POST",
+});
+
+// TODO: API 명세 업데이트 예정
+export const getMentorApplicationDetail = generateServiceFetcher<
+  { id: string | number },
+  void,
+  void,
+  MentorApplicationDetailResponse
+>({
+  endpoint: "/api/admin/mentor/{id}",
+  method: "GET",
+});
+
+// TODO: API 명세 업데이트 예정
+export const getMentorApplicationList = generateServiceFetcher<
+  void,
+  void,
+  void,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/admin/mentor",
+  method: "GET",
+});
+
+// TODO: API 명세 업데이트 예정
+export const approveMentorApplication = generateServiceFetcher<
+  { id: string | number },
+  void,
+  void,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/admin/mentor/{id}/approve",
+  method: "POST",
+});
+
+// TODO: API 명세 업데이트 예정
+export const rejectMentorApplication = generateServiceFetcher<
+  { id: string | number },
+  void,
+  void,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/admin/mentor/{id}/reject",
+  method: "POST",
+});
+
+// TODO: API 명세 업데이트 예정
+export const approveMentorInfoModification = generateServiceFetcher<
+  { id: string | number },
+  void,
+  void,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/admin/mentor/modify/{id}/approve",
+  method: "POST",
+});
+
+// TODO: API 명세 업데이트 예정
+export const rejectMentorInfoModification = generateServiceFetcher<
+  { id: string | number },
+  void,
+  void,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/admin/mentor/modify/{id}/reject",
+  method: "POST",
+});
+
+// TODO: API 명세 업데이트 예정
+export const getJobCategoryList = generateServiceFetcher<
+  void,
+  void,
+  void,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/admin/job",
+  method: "GET",
+});
+
+// TODO: API 명세 업데이트 예정
+export const postJobCategory = generateServiceFetcher<
+  void,
+  void,
+  void,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/admin/job",
+  method: "POST",
+});
+
+// TODO: API 명세 업데이트 예정
+export const putJobCategory = generateServiceFetcher<
+  void,
+  void,
+  void,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/admin/job/{id}",
+  method: "PUT",
+});
+
+// TODO: API 명세 업데이트 예정
+export const deleteJobCategory = generateServiceFetcher<
+  { id: string | number },
+  void,
+  void,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/admin/job/{id}",
+  method: "DELETE",
+});

--- a/packages/api/src/fetchers/apply-class/fetchers.ts
+++ b/packages/api/src/fetchers/apply-class/fetchers.ts
@@ -1,0 +1,40 @@
+import {
+  AppliedClassListResponse,
+  ApplyClassRequest,
+  ApplyClassResponse,
+} from "../../schemas/schemas";
+import { ServerSuccessResponse } from "../../schemas/server-response.schema";
+import { generateServiceFetcher } from "../generate-service-fetcher";
+
+export const applyClass = generateServiceFetcher<
+  void,
+  void,
+  ApplyClassRequest,
+  ServerSuccessResponse<ApplyClassResponse>
+>({
+  endpoint: "/api/apply",
+  method: "POST",
+});
+
+/**
+ * @description page: one-based index
+ */
+export const getAppliedClassList = generateServiceFetcher<
+  void,
+  { page: number; size: number },
+  void,
+  ServerSuccessResponse<AppliedClassListResponse>
+>({
+  endpoint: "/api/apply",
+  method: "GET",
+});
+
+export const cancelApplyClass = generateServiceFetcher<
+  { classId: number },
+  void,
+  void,
+  ServerSuccessResponse<null>
+>({
+  endpoint: "/api/apply/{classId}",
+  method: "DELETE",
+});

--- a/packages/api/src/fetchers/auth/fetchers.ts
+++ b/packages/api/src/fetchers/auth/fetchers.ts
@@ -1,0 +1,72 @@
+import { generateServiceFetcher } from "@/fetchers/generate-service-fetcher";
+import { ServerSuccessResponse, SignUpRequest } from "@/schemas";
+
+export const signUp = generateServiceFetcher<
+  void,
+  void,
+  SignUpRequest,
+  ServerSuccessResponse<{ message: string }>
+>({
+  endpoint: "/api/signup",
+  method: "POST",
+});
+
+export const validateEmail = generateServiceFetcher<
+  void,
+  { email: string },
+  void,
+  ServerSuccessResponse<{ isEmail: boolean }>
+>({
+  endpoint: "/api/signup/isEmail",
+  method: "GET",
+});
+
+export const requestSignUpVerifyCode = generateServiceFetcher<
+  void,
+  { email: string },
+  void,
+  null
+>({
+  endpoint: "/api/signup/verifyCode",
+  method: "POST",
+});
+
+export const verifySignUpVerifyCode = generateServiceFetcher<
+  void,
+  { email: string; verifyCode: string },
+  void,
+  { verifyEmail: boolean }
+>({
+  endpoint: "/api/signup/verifyCode",
+  method: "POST",
+});
+
+export const validateNickname = generateServiceFetcher<
+  void,
+  { nickname: string },
+  void,
+  ServerSuccessResponse<{ isNickname: boolean }>
+>({
+  endpoint: "/api/signup/isNickname",
+  method: "GET",
+});
+
+export const login = generateServiceFetcher<
+  void,
+  { email: string; password: string },
+  void,
+  null
+>({
+  endpoint: "/api/login",
+  method: "POST",
+});
+
+export const logout = generateServiceFetcher<
+  void,
+  void,
+  void,
+  { message: string }
+>({
+  endpoint: "/api/logout",
+  method: "POST",
+});

--- a/packages/api/src/fetchers/chat/fetchers.ts
+++ b/packages/api/src/fetchers/chat/fetchers.ts
@@ -1,0 +1,41 @@
+import { generateServiceFetcher } from "@/fetchers/generate-service-fetcher";
+import {
+  CreateChatRoomRequest,
+  CreateChatRoomResponse,
+  GetChatListResponse,
+  GetChatRoomHistoryRequest,
+  GetChatRoomHistoryResponse,
+} from "@/schemas";
+
+/**
+ * @description 로그인한 사용자가 참여 중인 모든 채팅방 목록을 반환합니다.
+ */
+export const getChatList = generateServiceFetcher<
+  void,
+  void,
+  void,
+  GetChatListResponse
+>({
+  endpoint: "/api/chat/rooms",
+  method: "GET",
+});
+
+export const createChatRoom = generateServiceFetcher<
+  void,
+  void,
+  CreateChatRoomRequest,
+  CreateChatRoomResponse
+>({
+  endpoint: "/api/chat/rooms",
+  method: "POST",
+});
+
+export const getChatRoomHistory = generateServiceFetcher<
+  { chatRoomId: number },
+  GetChatRoomHistoryRequest,
+  void,
+  GetChatRoomHistoryResponse
+>({
+  endpoint: "/api/chat/rooms/{chatRoomId}/messages",
+  method: "GET",
+});

--- a/packages/api/src/fetchers/class/fetchers.ts
+++ b/packages/api/src/fetchers/class/fetchers.ts
@@ -1,0 +1,70 @@
+import {
+  ClassDetailResponse,
+  ClassListResponse,
+  DeleteClassResponse,
+  PostClassRequest,
+  PutClassRequest,
+} from "../../schemas/schemas";
+import { ServerSuccessResponse } from "../../schemas/server-response.schema";
+import { generateServiceFetcher } from "../generate-service-fetcher";
+
+export const getClasses = generateServiceFetcher<
+  void,
+  {
+    job_id: string;
+    page: number;
+    sort_by: "created_at" | "title";
+    order: "asc" | "desc";
+  },
+  void,
+  ServerSuccessResponse<ClassListResponse>
+>({
+  endpoint: "/api/class",
+  method: "GET",
+});
+
+export const getClassDetail = generateServiceFetcher<
+  {
+    classId: string;
+  },
+  void,
+  void,
+  ServerSuccessResponse<ClassDetailResponse>
+>({
+  endpoint: "/api/class/{classId}",
+  method: "GET",
+});
+
+export const postClass = generateServiceFetcher<
+  void,
+  void,
+  PostClassRequest,
+  null
+>({
+  endpoint: "/api/class",
+  method: "POST",
+});
+
+export const putClass = generateServiceFetcher<
+  {
+    classId: string;
+  },
+  void,
+  PutClassRequest,
+  null
+>({
+  endpoint: "/api/class/{classId}",
+  method: "PUT",
+});
+
+export const deleteClass = generateServiceFetcher<
+  {
+    classId: string;
+  },
+  void,
+  void,
+  ServerSuccessResponse<DeleteClassResponse>
+>({
+  endpoint: "/api/class/{classId}",
+  method: "DELETE",
+});

--- a/packages/api/src/fetchers/files/fetchers.ts
+++ b/packages/api/src/fetchers/files/fetchers.ts
@@ -1,0 +1,57 @@
+import { ImageType } from "@/enums";
+import { FieldsError } from "@/errors";
+import { generateServiceFetcher } from "@/fetchers/generate-service-fetcher";
+import { ServerSuccessResponse, UploadFileResponse } from "@/schemas";
+
+export const uploadFile = generateServiceFetcher<
+  void,
+  void,
+  {
+    file: File;
+    imageType: ImageType;
+  },
+  ServerSuccessResponse<UploadFileResponse>
+>({
+  endpoint: "/api/files/upload",
+  method: "POST",
+  errorHandlerByCode: {
+    "400": (error) => {
+      if (FieldsError.isFieldsErrorBody(error.body)) {
+        throw new FieldsError(error.body.fields, error.body.message);
+      }
+      throw error;
+    },
+  },
+});
+
+export const deleteFile = generateServiceFetcher<
+  { fileId: string },
+  void,
+  void,
+  ServerSuccessResponse<null>
+>({
+  endpoint: "/api/files/{fileId}",
+  method: "DELETE",
+});
+
+export const downloadFile = generateServiceFetcher<
+  { fileId: string },
+  void,
+  void,
+  Blob
+>({
+  endpoint: "/api/files/{fileId}/download",
+  method: "GET",
+  responseContentType: "blob",
+});
+
+export const downloadImage = generateServiceFetcher<
+  { uniqueIdentifier: string },
+  { width?: number; height?: number },
+  void,
+  Blob
+>({
+  endpoint: "/api/files/markdown-images/{uniqueIdentifier}",
+  method: "GET",
+  responseContentType: "blob",
+});

--- a/packages/api/src/fetchers/generate-service-fetcher.ts
+++ b/packages/api/src/fetchers/generate-service-fetcher.ts
@@ -1,0 +1,12 @@
+import { ServiceError } from "../errors/service-error";
+import { generateFetcher } from "../utils/api-fetcher/generateFetcher";
+
+export const generateServiceFetcher: typeof generateFetcher = (options) => {
+  return generateFetcher({
+    ...options,
+    base: import.meta.env.VITE_API_BASE_URL ?? "/",
+    errorHandler: (error) => {
+      throw ServiceError.byHTTPError(error);
+    },
+  });
+};

--- a/packages/api/src/fetchers/index.ts
+++ b/packages/api/src/fetchers/index.ts
@@ -1,0 +1,19 @@
+import * as adminFetchers from "./admin/fetchers";
+import * as applyClassFetchers from "./apply-class/fetchers";
+import * as authFetchers from "./auth/fetchers";
+import * as chatFetchers from "./chat/fetchers";
+import * as classFetchers from "./class/fetchers";
+import * as filesFetchers from "./files/fetchers";
+import * as memberFetchers from "./member/fetchers";
+import * as mentorFetchers from "./mentor/fetchers";
+
+export const dementorApiFetchers = {
+  admin: adminFetchers,
+  applyClass: applyClassFetchers,
+  auth: authFetchers,
+  chat: chatFetchers,
+  class: classFetchers,
+  files: filesFetchers,
+  member: memberFetchers,
+  mentor: mentorFetchers,
+};

--- a/packages/api/src/fetchers/member/fetchers.ts
+++ b/packages/api/src/fetchers/member/fetchers.ts
@@ -1,0 +1,26 @@
+import { generateServiceFetcher } from "@/fetchers/generate-service-fetcher";
+import {
+  GetMyMemberInfoResponse,
+  PutMyMemberInfoRequest,
+  ServerSuccessResponse,
+} from "@/schemas";
+
+export const getMyMemberInfo = generateServiceFetcher<
+  void,
+  void,
+  void,
+  ServerSuccessResponse<GetMyMemberInfoResponse>
+>({
+  endpoint: "/api/member/me",
+  method: "GET",
+});
+
+export const putMyMemberInfo = generateServiceFetcher<
+  void,
+  void,
+  PutMyMemberInfoRequest,
+  null
+>({
+  endpoint: "/api/member/me",
+  method: "PUT",
+});

--- a/packages/api/src/fetchers/mentor/fetchers.ts
+++ b/packages/api/src/fetchers/mentor/fetchers.ts
@@ -1,0 +1,188 @@
+import { ApplyStatus } from "@/enums";
+import { ConflictingAppointmentError, FieldsError } from "@/errors";
+import {
+  AppliedMenteeListResponse,
+  GetMentorAvailableScheduleRequest,
+  GetMentorAvailableScheduleResponse,
+  GetMentorInfoModificationRequestListRequest,
+  GetMentorInfoModificationRequestListResponse,
+  HandleMentoringApplicationResponse,
+  MentorInfoResponse,
+  MentorRoleApplicationRequest,
+  PutMentorAvailableSchedulePathParams,
+  PutMentorAvailableScheduleRequest,
+  PutMentorAvailableScheduleResponse,
+  RegisteredClassListResponse,
+  RequestUpdateMentorInfoRequest,
+  RequestUpdateMentorInfoResponse,
+  UpdateMentoringScheduleRequest,
+  UpdateMentoringScheduleResponse,
+} from "../../schemas/schemas";
+import { ServerSuccessResponse } from "../../schemas/server-response.schema";
+import { generateServiceFetcher } from "../generate-service-fetcher";
+
+export const getRegisteredClassList = generateServiceFetcher<
+  { memberId: string },
+  void,
+  void,
+  ServerSuccessResponse<RegisteredClassListResponse>
+>({
+  endpoint: "/api/mentor/class/{memberId}",
+  method: "GET",
+});
+
+/**
+ * @description 멘토가 자신의 멘토링 신청한 멘티 목록을 조회하기 위한 API 엔드 포인트
+ * @param page 페이지 번호. one-based index
+ * @param size 페이지 크기
+ * @default page = 1, size = 10
+ */
+export const getAppliedMenteeList = generateServiceFetcher<
+  void,
+  { page?: number; size?: number },
+  void,
+  ServerSuccessResponse<AppliedMenteeListResponse>
+>({
+  endpoint: "/api/mentor/apply",
+  method: "GET",
+});
+
+export const handleMentoringApplication = generateServiceFetcher<
+  { applyId: string | number },
+  void,
+  { status: ApplyStatus },
+  ServerSuccessResponse<HandleMentoringApplicationResponse>
+>({
+  endpoint: "/api/mentor/apply/{applyId}/status",
+  method: "POST",
+});
+
+/**
+ * @description 멘토로서의 본인 정보를 조회합니다.
+ */
+export const getMentorInfo = generateServiceFetcher<
+  { memberId: string },
+  void,
+  void,
+  ServerSuccessResponse<MentorInfoResponse>
+>({
+  endpoint: "/api/mentor/{memberId}/info",
+  method: "GET",
+});
+
+/**
+ * @description 멘토 지원을 합니다.
+ */
+export const applyForMentorRole = generateServiceFetcher<
+  void,
+  void,
+  MentorRoleApplicationRequest,
+  ServerSuccessResponse<null>
+>({
+  endpoint: "/api/mentor",
+  method: "POST",
+  errorHandlerByCode: {
+    "400": (error) => {
+      if (FieldsError.isFieldsErrorBody(error.body)) {
+        throw new FieldsError(error.body.fields, error.body.message);
+      }
+      throw error;
+    },
+  },
+});
+
+/**
+ * @description 기존 멘토 정보를 수정합니다. 관리자의 승인이 필요합니다.
+ */
+export const requestUpdateMentorInfo = generateServiceFetcher<
+  { memberId: string },
+  void,
+  RequestUpdateMentorInfoRequest,
+  ServerSuccessResponse<RequestUpdateMentorInfoResponse>
+>({
+  endpoint: "/api/mentor/{memberId}",
+  method: "PUT",
+});
+
+export const getMentorInfoModificationRequestList = generateServiceFetcher<
+  { memberId: string },
+  GetMentorInfoModificationRequestListRequest,
+  void,
+  ServerSuccessResponse<GetMentorInfoModificationRequestListResponse>
+>({
+  endpoint: "/api/mentor/{memberId}/modification-request",
+  method: "GET",
+  errorHandlerByCode: {
+    "400": (error) => {
+      if (FieldsError.isFieldsErrorBody(error.body)) {
+        throw new FieldsError(error.body.fields, error.body.message);
+      }
+      throw error;
+    },
+  },
+});
+
+export const updateMentoringSchedule = generateServiceFetcher<
+  { memberId: string },
+  void,
+  UpdateMentoringScheduleRequest,
+  ServerSuccessResponse<UpdateMentoringScheduleResponse>
+>({
+  endpoint: "/api/mentor/{memberId}/schedule",
+  method: "PUT",
+  errorHandlerByCode: {
+    "400": (error) => {
+      if (FieldsError.isFieldsErrorBody(error.body)) {
+        throw new FieldsError(error.body.fields, error.body.message);
+      }
+      throw error;
+    },
+    "409": (error) => {
+      if (
+        ConflictingAppointmentError.isConflictingAppointmentBody(error.body)
+      ) {
+        throw new ConflictingAppointmentError(
+          error.body.data.conflictingAppointments,
+          error.body.message
+        );
+      }
+      throw error;
+    },
+  },
+});
+
+export const getMentorAvailableSchedule = generateServiceFetcher<
+  { memberId: string },
+  GetMentorAvailableScheduleRequest,
+  void,
+  ServerSuccessResponse<GetMentorAvailableScheduleResponse>
+>({
+  endpoint: "/api/mentor/{memberId}/availability",
+  method: "GET",
+  errorHandlerByCode: {
+    "400": (error) => {
+      if (FieldsError.isFieldsErrorBody(error.body)) {
+        throw new FieldsError(error.body.fields, error.body.message);
+      }
+      throw error;
+    },
+  },
+});
+
+export const putMentorAvailableSchedule = generateServiceFetcher<
+  PutMentorAvailableSchedulePathParams,
+  void,
+  PutMentorAvailableScheduleRequest,
+  ServerSuccessResponse<PutMentorAvailableScheduleResponse>
+>({
+  endpoint: "/api/mentor/{memberId}/availability/{yearMonthDay}",
+  method: "PUT",
+  errorHandlerByCode: {
+    "400": (error) => {
+      if (FieldsError.isFieldsErrorBody(error.body)) {
+        throw new FieldsError(error.body.fields, error.body.message);
+      }
+      throw error;
+    },
+  },
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./enums";
+export * from "./errors";
+export * from "./fetchers";
+export * from "./schemas";

--- a/packages/api/src/schemas/index.ts
+++ b/packages/api/src/schemas/index.ts
@@ -1,0 +1,2 @@
+export * from "./schemas";
+export * from "./server-response.schema";

--- a/packages/api/src/schemas/schemas.ts
+++ b/packages/api/src/schemas/schemas.ts
@@ -1,0 +1,695 @@
+import {
+  ApplyStatus,
+  ChatRoomType,
+  DateOfWeek,
+  MessageSenderType,
+  MessageType,
+} from "../enums/enums";
+
+export type ClassListResponse = {
+  classes: {
+    classId: number;
+    mentor: {
+      mentorId: number;
+      name: string;
+      job: string;
+      career: number;
+    };
+    stack: string[];
+    content: string;
+    title: string;
+    price: number;
+  }[];
+  page: {
+    totalDataCnt: number; // 총 데이터 수
+    totalPages: number; // 총 페이지 수
+    isLastPage: boolean; // 요청한 리소스가 마지막 페이지인지 세팅한다
+    isFirstPage: boolean; // 요청한 리소스가
+    requestPage: number; // 요청한 페이지 번호
+    requestSize: number; // 요청한 페이지 번호에서 데이터 수
+  };
+};
+
+export type ClassDetailResponse = {
+  classId: number;
+  mentor: {
+    mentorId: number;
+    name: string;
+    job: string;
+    career: number;
+  };
+  stack: string;
+  content: string;
+  title: string;
+  price: number;
+};
+
+type CommonClassRequest = {
+  /**
+   * @description 기술 스택
+   */
+  stack: string[];
+  /**
+   * @description 수업 내용
+   */
+  content: string;
+  /**
+   * @description 수업 제목
+   */
+  title: string;
+  /**
+   * @description 수업 가격
+   */
+  price: number;
+  /**
+   * @description 수업 일정
+   */
+  schedule: {
+    /**
+     * @description 요일
+     */
+    date_of_week: DateOfWeek;
+    /**
+     * @description 시간 예시: "10001100 : 오전 10시 ~ 오전 11시"
+     */
+    time: string;
+  };
+};
+
+export type PostClassRequest = CommonClassRequest;
+
+export type PutClassRequest = CommonClassRequest;
+
+export type PutClassResponse = CommonClassRequest & {
+  classId: string;
+  mentor: {
+    mentorId: number;
+    name: string;
+    job: string;
+    career: number;
+  };
+};
+
+export type DeleteClassResponse = {
+  classId: string;
+};
+
+export type RegisteredClassListResponse = {
+  class_id: number;
+  mentor: {
+    member_id: number;
+    name: string;
+    job: string;
+    career: number;
+  };
+  stack: string;
+  content: string;
+  title: string;
+  price: number;
+  mentee: {
+    member_id: number;
+    date: Date;
+  }[];
+};
+export type AppliedMenteeListResponse = {
+  applyments: {
+    /**
+     * @description 신청된 아이디(기본 아이디)
+     */
+    applymentId: number;
+    classId: number;
+    memberId: number;
+    nickname: string;
+    /**
+     * @description 신청 상태
+     */
+    status: ApplyStatus;
+    /**
+     * @description 멘티 문의
+     */
+    inquiry: string;
+    /**
+     * @description 신청 날짜 e.g. 2025-03-24T14:30+09:00 (UTC 기준 9시간 이후[한국])
+     */
+    schedule: string;
+  }[];
+  pagination: {
+    page: number;
+    size: number;
+    total_elements: number;
+    total_pages: number;
+  };
+};
+
+export type AppliedClassListResponse = {
+  applyments: {
+    /**
+     * @description 신청된 아이디(기본 아이디)
+     */
+    applymentId: number;
+    /**
+     * @description 클래스 아이디
+     */
+    classId: number;
+    /**
+     * @description 멘토 아이디
+     */
+    mentorId: number;
+    /**
+     * @description 멘토 이름
+     */
+    name: string;
+    /**
+     * @description 신청 상태
+     */
+    status: ApplyStatus;
+    /**
+     * @description 멘티 문의
+     */
+    inquiry: string;
+    /**
+     * @description 신청 날짜 e.g. 2025-03-24T14:00+09:00 (UTC 기준 9시간 이후[한국])
+     */
+    schedule: string;
+  }[];
+  pagination: {
+    /**
+     * @description 페이지 크기
+     */
+    size: number;
+    /**
+     * @description 총 요소 수
+     */
+    total_elements: number;
+    /**
+     * @description 페이지 번호. one-based index
+     */
+    page: number;
+    /**
+     * @description 총 페이지 수
+     */
+    total_pages: number;
+  };
+};
+
+export type ApplyClassRequest = {
+  /**
+   * @description 클래스 아이디
+   */
+  classId: number;
+  /**
+   * @description 멘티에게 남길 메시지
+   */
+  inquiry: string;
+  /**
+   * @description 신청일정 예시: ISO 8601 형식. e.g. "2025-03-24T14:30+09:00 (UTC 기준 9시간 이후[한국])"
+   */
+  schedule: string;
+};
+
+export type ApplyClassResponse = {
+  applymentId: number;
+};
+
+export type SignUpRequest = {
+  name: string;
+  email: string;
+  nickname: string;
+  password: string;
+  /**
+   * @description 이메일 인증 코드
+   */
+  verifyCode: string;
+};
+
+export type GetMyMemberInfoResponse = {
+  id: string;
+  email: string;
+  nickname: string;
+  /**
+   * @description ISO 8601 형식. e.g. "2025-03-24T14:00+09:00 (UTC 기준 9시간 이후[한국])"
+   */
+  created_at: string;
+};
+
+export type PutMyMemberInfoRequest = {
+  nickname: string;
+};
+
+export type MentorApplicationDetailResponse = {
+  id: number;
+  name: string;
+  job: string;
+  career: number;
+  currentCompany: string;
+  phone: string;
+  /**
+   * @description 자기소개
+   */
+  introduction: string;
+  /**
+   * @description 최고로 해당 멘토를 추천하는 분야
+   */
+  bestFor: string;
+  /**
+   * @description 지원날짜. ISO 8601 형식. e.g. "2025-03-24T14:00+09:00 (UTC 기준 9시간 이후[한국])"
+   */
+  applicationDate: string;
+  // TODO: 아마 응답 구조가 바뀔 것임.
+  attachment: File;
+};
+
+export type HandleMentoringApplicationResponse = {
+  applymentId: number;
+  classId: string;
+  status: ApplyStatus;
+};
+
+export type MentorInfoResponse = {
+  memberInfo: {
+    /**
+     * @description 회원(멘토) ID
+     */
+    memberId: number;
+    /**
+     * @description 멘토 이름(실명)
+     */
+    name: string;
+    job: {
+      /**
+       * @description 직무ID
+       */
+      jobId: number;
+      /**
+       * @description 직무명
+       */
+      jobName: string;
+    };
+    /**
+     * @description 경력
+     */
+    career: number;
+    /**
+     * @description 전화번호
+     */
+    phone: string;
+    /**
+     * @description 현재 직장
+     */
+    currentCompany: string;
+    /**
+     * @description "나를 소개하는 글" 소개글
+     */
+    introduction: string;
+    /**
+     * @description 추천 대상
+     */
+    bestFor: string;
+    ApprovalStatus: ApplyStatus;
+    /**
+     * @description 작성한 멘토링 수
+     */
+    totalClasses: number;
+    /**
+     * @description 멘토가 아직 승인하지 않은 멘토링 신청 개수
+     */
+    pendingRequests: number;
+    /**
+     * @description 완료된 멘토링 수
+     */
+    completedSessions: number;
+  };
+};
+
+export type MentorRoleApplicationRequest = {
+  /**
+   * @description 사용자 ID
+   */
+  memberId: number | string;
+  /**
+   * @description 멘토 이름(실명)
+   */
+  name: string;
+  /**
+   * @description 직무 ID
+   */
+  jobId: number;
+  /**
+   * @description 전화번호 (digit only e.g. 01012345678)
+   */
+  phone: string;
+  /**
+   * @description 연락할 이메일
+   */
+  email: string;
+  /**
+   * @description 경력(년차)
+   */
+  career: number;
+  /**
+   * @description 현재 기업
+   */
+  currentCompany: string;
+  /**
+   * @description "나를 소개하는 글" (마크다운 형식)
+   */
+  introduction: string;
+  /**
+   * @description "이런 분들에게 좋아요" 질문에 대한 답변
+   */
+  bestFor: string;
+  /**
+   * @description 경력증명서 파일 ID 목록 (여러 파일 첨부 가능)
+   */
+  attachmentId: number[];
+};
+export type RequestUpdateMentorInfoRequest = {
+  job: {
+    /**
+     * @description 직문
+     */
+    jobId: number;
+    /**
+     * @description 직문
+     */
+    jobName: string;
+  };
+  /**
+   * @description 경력
+   */
+  career: number;
+  /**
+   * @description 전화번호
+   */
+  phone: string;
+  /**
+   * @description 현재 회사
+   */
+  currentCompany: string;
+  /**
+   * @description 소개글
+   */
+  introduction: string;
+  /**
+   * @description "이런 분들에게 좋아요" 추천대상
+   */
+  bestFor: string;
+  /**
+   * @description 첨부 파일 ID 목록 (여러 파일 첨부 가능)
+   */
+  attachmentId: number[];
+};
+
+export type RequestUpdateMentorInfoResponse = {
+  memberId: number;
+  /**
+   * @description 수정 요청 상태 (관리자 승인 대기 중)
+   */
+  modification_status: ApplyStatus;
+};
+
+export type GetMentorInfoModificationRequestListRequest = {
+  status: ApplyStatus;
+  page: number;
+  size: number;
+};
+/**
+ * @description 멘토 정보 수정 요청 목록 응답 타입
+ */
+export type GetMentorInfoModificationRequestListResponse = {
+  /**
+   * @description 수정 요청 목록
+   */
+  modificationRequests: {
+    /**
+     * @description 수정 요청 ID
+     */
+    modificationId: number;
+    /**
+     * @description 수정 요청 상태 ("PENDING", "APPROVED", "REJECTED" 중 하나)
+     */
+    status: ApplyStatus;
+    /**
+     * @description 요청 날짜 (ISO 8601 형식, UTC+9 한국 시간)
+     */
+    requestDate: string;
+    /**
+     * @description 수정된 필드들
+     */
+    modifiedFields: {
+      /**
+       * @description 경력 변경 정보
+       */
+      career: {
+        /**
+         * @description 변경 전 값
+         */
+        before: number;
+        /**
+         * @description 변경 후 값
+         */
+        after: number;
+      };
+      /**
+       * @description 소개글 변경 정보
+       */
+      introduction: {
+        /**
+         * @description 변경 전 값
+         */
+        before: string;
+        /**
+         * @description 변경 후 값
+         */
+        after: string;
+      };
+      /**
+       * @description 추천 대상 변경 정보
+       */
+      bestFor: {
+        /**
+         * @description 변경 전 값 (없을 경우 null)
+         */
+        before: string | null;
+        /**
+         * @description 변경 후 값
+         */
+        after: string;
+      };
+    };
+  }[];
+  /**
+   * @description 페이지네이션 정보
+   */
+  pagination: {
+    /**
+     * @description 현재 페이지
+     */
+    page: number;
+    /**
+     * @description 페이지 크기
+     */
+    size: number;
+    /**
+     * @description 전체 요소 수
+     */
+    totalElements: number;
+  };
+};
+
+export type UploadFileResponse = Array<{
+  /**
+   * @description 저장된 파일의 ID
+   */
+  attachmentId: number;
+  /**
+   * @description 원본 파일명
+   */
+  originalFilename: string;
+  /**
+   * @description 파일 크기 (단위: 바이트)
+   */
+  fileSize: number;
+  /**
+   * @description 마크다운에서 참조할 URL (imageType이 MARKDOWN*인 경우)
+   */
+  fileUrl: string;
+  /**
+   * @description 마크다운 내 이미지 참조용 식별자 (imageType이 MARKDOWN인 경우)
+   */
+  uniqueIdentifier: string;
+}>;
+
+export type GetChatListResponse = Array<{
+  chatRoomId: number;
+  /**
+   * @description number일 경우 멘토링 신청으로 생성된 챗. null일 경우 관리자문의 챗
+   */
+  applymentId?: number | null;
+  /**
+   * @description 멘티 닉네임
+   */
+  nickname: string;
+  /**
+   * @description 마지막 메시지
+   */
+  lastMessage: string;
+  /**
+   * @description 마지막 메시지 보낸 시간
+   */
+  lastSentAt: string;
+}>;
+
+export type CreateMentoringChatRoomRequest = {
+  roomType: ChatRoomType.MENTORING;
+  applymentId: number;
+};
+
+export type CreateAdminChatRoomRequest = {
+  roomType: ChatRoomType.ADMIN;
+};
+
+export type CreateChatRoomRequest =
+  | CreateMentoringChatRoomRequest
+  | CreateAdminChatRoomRequest;
+
+export type CreateChatRoomResponse = {
+  roomType: ChatRoomType;
+  chatRoomId: number;
+};
+
+export type GetChatRoomHistoryRequest = {
+  beforeMessageId?: number;
+  size: number;
+};
+
+export type GetChatRoomHistoryResponse = {
+  messages: Array<{
+    messageId: number;
+    type: MessageType;
+    senderType: MessageSenderType;
+    memberId: number;
+    nickname: string;
+    message: string;
+    createdAt: string;
+  }>;
+  hasMore: boolean;
+  nextCursor: number;
+};
+
+export type UpdateMentoringScheduleRequest = {
+  /**
+   * @description 멘토링 클래스 ID
+   */
+  classId: number;
+  /**
+   * @description 원래 일정 날짜 (YYYY-MM-DD)
+   */
+  yearMonthDay: string;
+  /**
+   * @description [0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0] 9시 예약
+   */
+  timePattern: number[];
+  /**
+   * @description 멘토링 신청 ID
+   */
+  applymentId: number;
+  /**
+   * @description 새 날짜 (같은 날짜 내 변경 시 생략 가능)
+   */
+  newYearMonthDay?: string;
+  /**
+   * @description [0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0] 14시 예약
+   */
+  newTimePattern?: number[];
+};
+
+export type UpdateMentoringScheduleResponse = {
+  /**
+   * @description 작업이 적용된 날짜(YYYY-MM-DD)
+   */
+  yearMonthDay: string;
+  /**
+   * @description [0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0] 업데이트된 시간 패턴
+   */
+  updatedTimePattern: number[];
+  /**
+   * @description 멘토링 신청 ID
+   */
+  applymentId: number;
+};
+
+export type GetMentorAvailableScheduleRequest = {
+  /**
+   * @description 연월일 (YYYY-MM-DD)
+   */
+  yearMonthDay: string;
+  /**
+   * @description 멘토링 클래스 ID (선택적)
+   */
+  classId?: number;
+};
+
+export type GetMentorAvailableScheduleResponse = {
+  /**
+   * @description 멘토 ID
+   */
+  memberId: number;
+  /**
+   * @description 연월일 (YYYY-MM-DD)
+   */
+  yearMonthDay: string; // "YYYY-MM-DD"
+  /**
+   * @description 해당 월의 총 일수
+   */
+  daysInMonth: number; // 해당 월의 총 일수
+  availableDates: {
+    /**
+     * @description 날짜 (YYYY-MM-DD)
+     */
+    date: string; // "YYYY-MM-DD"
+    /**
+     * @description 사용 가능한 시간 슬롯. e.g. ["09:00-10:00", "14:00-15:00"]
+     */
+    availableTimeSlots: string[];
+    /**
+     * @description 예약된 시간 슬롯. e.g. ["16:00-17:00"]
+     */
+    bookedTimeSlots: string[];
+  }[];
+};
+
+export type PutMentorAvailableSchedulePathParams = {
+  /**
+   * @description 멘토 ID
+   */
+  memberId: string;
+  /**
+   * @description 연월일 (YYYY-MM-DD)
+   */
+  yearMonthDay: string;
+};
+
+/**
+ * @description 멘토 가용 일정 수정 요청 타입
+ */
+export type PutMentorAvailableScheduleRequest = {
+  classId: number; // 멘토링 클래스 ID
+  /**
+   * @description 시간 패턴
+   * e.g. [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,1,0,0,0,0,0] 기존 시간대 : 16-17시, 19시 가용
+   * e.g. [0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,1,0,0,0,0,0,0,0] 변경 시간대 : 15시 17시 가용상태
+   * 15시는 추가, 16,19시는 삭제!
+   */
+  timePattern: number[];
+};
+export type PutMentorAvailableScheduleResponse = {
+  /**
+   * @description 연월일 (YYYY-MM-DD)
+   */
+  yearMonthDay: string;
+  /**
+   * @description 가용 시간대 문자열 배열 (HH:MM-HH:MM 형식)
+   */
+  availableTimeSlots: string[];
+};

--- a/packages/api/src/schemas/server-response.schema.ts
+++ b/packages/api/src/schemas/server-response.schema.ts
@@ -1,0 +1,27 @@
+export type ServerSuccessResponse<T> = {
+  data: T;
+  message: string;
+  success: true;
+};
+
+export type ServerErrorResponse<E = Record<string, unknown>> = {
+  error?: E;
+  code: string;
+  details: string;
+};
+
+export function isServerSuccessResponse<T>(
+  response: unknown
+): response is ServerSuccessResponse<T> {
+  if (typeof response !== "object" || response === null) return false;
+  const { success } = response as ServerSuccessResponse<T>;
+  return !!success;
+}
+
+export function isServerErrorResponse(
+  response: unknown
+): response is ServerErrorResponse {
+  if (typeof response !== "object" || response === null) return false;
+  const { code } = response as ServerErrorResponse;
+  return parseInt(code) >= 400;
+}

--- a/packages/api/src/utils/api-fetcher/HTTPError.ts
+++ b/packages/api/src/utils/api-fetcher/HTTPError.ts
@@ -1,0 +1,28 @@
+import { CustomError } from "ts-custom-error";
+
+export class HTTPError extends CustomError {
+  code: string;
+  body?: object;
+
+  constructor(code: string, body?: unknown) {
+    if (typeof body === "string") {
+      super(body);
+    } else if (hasMessage(body)) {
+      super(body.message);
+    } else {
+      super(JSON.stringify(body));
+    }
+    this.code = code;
+    if (typeof body === "object" && body !== null) {
+      this.body = body;
+    }
+  }
+
+  static isHTTPError(error: unknown): error is HTTPError {
+    return error instanceof HTTPError;
+  }
+}
+
+function hasMessage(body: unknown): body is { message: string } {
+  return typeof body === "object" && body !== null && "message" in body;
+}

--- a/packages/api/src/utils/api-fetcher/README.md
+++ b/packages/api/src/utils/api-fetcher/README.md
@@ -1,0 +1,121 @@
+# API Fetcher
+
+API 요청을 생성하고 처리하기 위한 유틸리티 모듈입니다.
+
+## 주요 기능
+
+- 타입 안전한 API 요청 생성
+- Path 파라미터, 쿼리 파라미터, 요청 본문 지원
+- 에러 핸들링
+- 다양한 콘텐츠 타입 지원 (JSON, Form-data)
+- 응답 형식 지원 (JSON, Text, Blob)
+
+## 사용법
+
+### 기본 Fetcher 생성
+
+```ts
+const getFetcher = generateFetcher({
+  base: "https://api.example.com",
+  endpoint: "/users",
+  method: "GET",
+});
+```
+
+### Path 파라미터 사용
+
+```ts
+const getUserFetcher = generateFetcher<{ id: string }>({
+  endpoint: "/users/{id}",
+  method: "GET",
+});
+// 사용
+await getUserFetcher({
+  pathParams: { id: "123" },
+});
+```
+
+### 쿼리 파라미터 사용
+
+```ts
+const searchUsersFetcher = generateFetcher<
+  void,
+  { query: string; page: number }
+>({
+  endpoint: "/users/search",
+  method: "GET",
+});
+// 사용
+await searchUsersFetcher({
+  queryParam: { query: "john", page: 1 },
+});
+```
+
+### 요청 본문 사용
+
+```ts
+type CreateUserBody = {
+  name: string;
+  email: string;
+};
+const createUserFetcher = generateFetcher<void, void, CreateUserBody>({
+  endpoint: "/users",
+  method: "POST",
+});
+// 사용
+await createUserFetcher({
+  body: { name: "John", email: "john@example.com" },
+});
+```
+
+### 응답 타입 지정
+
+```ts
+const getUserFetcher = generateFetcher<void, void, void, { name: string }>({
+  endpoint: "/user",
+  method: "GET",
+});
+// 사용
+const user = await getUserFetcher(); // { name: "John" }
+```
+
+### 에러 핸들링
+
+```ts
+const fetcher = generateFetcher({
+  endpoint: "/api",
+  errorHandlers: {
+    "404": (error) => {
+      // 404 에러 처리
+    },
+    "500": (error) => {
+      // 500 에러 처리
+    },
+  },
+});
+```
+
+## 타입 정의
+
+### FetcherGeneratorOptions
+
+```ts
+interface FetcherGeneratorOptions {
+  base?: string; // 기본 URL
+  endpoint?: string; // 엔드포인트 경로
+  method?: string; // HTTP 메서드
+  requestContentType?: "json" | "form-data"; // 요청 콘텐츠 타입
+  responseContentType?: "json" | "text" | "blob"; // 응답 콘텐츠 타입
+  errorHandlers?: {
+    // 에러 핸들러
+    [statusCode: string]: (error: ServerError) => void;
+  };
+  credentialMode?: RequestCredentials; // 인증 모드
+}
+```
+
+## 주의사항
+
+- Path 파라미터는 `{paramName}` 형식으로 endpoint에 지정해야 합니다.
+- 배열 형태의 쿼리 파라미터는 쉼표(,)로 구분된 문자열로 직렬화됩니다.
+- 서버 에러 응답은 `ServerError` 형식으로 변환되어 처리됩니다.

--- a/packages/api/src/utils/api-fetcher/generateFetcher.ts
+++ b/packages/api/src/utils/api-fetcher/generateFetcher.ts
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { HTTPError } from "./HTTPError";
+
+type SerializableObject = Record<
+  string,
+  string | number | boolean | string[] | number[]
+>;
+
+export type WithPathParams<PathParams extends SerializableObject> = {
+  pathParams: PathParams;
+};
+
+export type WithQueryParams<QueryParams extends SerializableObject> = {
+  queryParam: QueryParams;
+};
+
+export type WithBody<Body> = {
+  body: Body;
+};
+
+export type FetcherRequestOptions<
+  PathParams extends SerializableObject | void = {
+    [key: string]: string | number | boolean;
+  } | void,
+  QueryParam extends SerializableObject | void = any,
+  Body extends Record<string, any> | void = any,
+  Header extends HeadersInit | void = HeadersInit,
+> = {
+  baseUrl?: string;
+} & (QueryParam extends SerializableObject
+  ? WithQueryParams<QueryParam>
+  : {
+      queryParam?: any;
+    }) &
+  (PathParams extends SerializableObject
+    ? WithPathParams<PathParams>
+    : {
+        pathParams?: any;
+      }) &
+  (Body extends Record<string, any>
+    ? WithBody<Body>
+    : {
+        body?: any;
+      }) &
+  (Header extends SerializableObject
+    ? {
+        headers?: Header;
+      }
+    : {
+        headers?: never;
+      }) &
+  Omit<RequestInit, "body" | "headers">;
+
+type Fetcher<
+  FetcherOptions extends FetcherRequestOptions = FetcherRequestOptions,
+  FetcherResponse = any,
+> = (options?: FetcherOptions) => Promise<FetcherResponse>;
+
+export interface FetcherGeneratorOptions {
+  base?: string;
+  endpoint?: string;
+  method?: string;
+  requestContentType?: "json" | "form-data";
+  responseContentType?: "json" | "text" | "blob";
+  errorHandlerByCode?: {
+    [statusCode: string]: (error: HTTPError) => void;
+  };
+  errorHandler?: (error: HTTPError) => void;
+  credentialMode?: RequestCredentials;
+}
+
+export function generateFetcher<
+  RequestPathParams extends SerializableObject | void = SerializableObject,
+  RequestQueryParams extends SerializableObject | void = SerializableObject,
+  RequestBody extends Record<string, any> | void = any,
+  Response = any,
+  Header extends HeadersInit | void = HeadersInit,
+>({
+  base = "",
+  endpoint = "",
+  method = "GET",
+  requestContentType = "json",
+  responseContentType = "json",
+  errorHandlerByCode = {},
+  errorHandler,
+  credentialMode,
+}: FetcherGeneratorOptions = {}) {
+  const createUrl = (
+    baseUrl: string,
+    pathParams?: RequestPathParams,
+    queryParam?: RequestQueryParams
+  ) => {
+    const endPointWithPathParamsReplaced = pathParams
+      ? Object.keys(pathParams).reduce(
+          (acc, key) => acc.replace(`{${key}}`, `${pathParams[key]}`),
+          endpoint
+        )
+      : endpoint;
+    const queryString = queryParam
+      ? `?${Object.entries(queryParam)
+          .filter(([, value]) => value !== undefined)
+          // TODO: , seperator로 할지, 복수 query param으로 할지 옵션을 제공할 수 있도록 변경
+          // 요소가 배열인경우, ","를 seperator로 직렬화
+          .map(([key, value]) => {
+            let serializedValue: string | number | boolean;
+            if (Array.isArray(value)) {
+              serializedValue = value.join(",");
+            } else {
+              serializedValue = value;
+            }
+            return `${key}=${encodeURIComponent(serializedValue)}`;
+          })
+          .join("&")}`
+      : "";
+    return `${baseUrl}${endPointWithPathParamsReplaced}${queryString}`;
+  };
+
+  const createHeaders = (headers?: HeadersInit) => {
+    const newHeaders = new Headers(headers);
+    if (requestContentType === "json") {
+      newHeaders.append("Content-Type", "application/json");
+    }
+    return newHeaders;
+  };
+
+  const createBody = (body?: any) => {
+    if (!body) return undefined;
+    if (requestContentType === "form-data") {
+      const formData = new FormData();
+      Object.keys(body).forEach((key) => {
+        formData.append(key, body[key]);
+      });
+      return formData;
+    }
+    return JSON.stringify(body);
+  };
+
+  const fetcher: Fetcher<
+    FetcherRequestOptions<
+      RequestPathParams,
+      RequestQueryParams,
+      RequestBody,
+      Header
+    >,
+    Response
+  > = async (options) => {
+    const {
+      baseUrl = base,
+      pathParams = undefined,
+      queryParam = undefined,
+      body = undefined,
+      headers,
+      ...requestOptions
+    } = options ?? {};
+
+    try {
+      const res = await fetch(createUrl(baseUrl, pathParams, queryParam), {
+        method,
+        headers: createHeaders(headers),
+        body: createBody(body),
+        credentials: credentialMode,
+        ...requestOptions,
+      });
+
+      if (!res.ok) {
+        const body = res.body ? await res.json() : undefined;
+        const httpError = new HTTPError(res.status.toString(), body);
+        if (httpError.code && errorHandlerByCode[httpError.code]) {
+          return errorHandlerByCode[httpError.code](httpError);
+        } else if (errorHandler) {
+          return errorHandler(httpError);
+        } else {
+          throw httpError;
+        }
+      }
+
+      let data;
+      switch (responseContentType) {
+        case "json":
+          data = await res.json();
+          break;
+        case "text":
+          data = await res.text();
+          break;
+        case "blob":
+          data = await res.blob();
+          break;
+      }
+
+      return data;
+    } catch (e) {
+      if (HTTPError.isHTTPError(e)) {
+        throw e;
+      }
+      throw e;
+    }
+  };
+
+  return fetcher;
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/api/vite.config.ts
+++ b/packages/api/vite.config.ts
@@ -1,0 +1,43 @@
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  plugins: [
+    dts({
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/*.spec.ts"],
+      outDir: "dist",
+      rollupTypes: true,
+      insertTypesEntry: true,
+      tsconfigPath: "./tsconfig.json",
+      staticImport: true,
+      clearPureImport: true,
+    }),
+  ],
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      formats: ["es", "cjs"],
+      fileName: (format) => `index.${format === "es" ? "js" : "cjs"}`,
+    },
+    rollupOptions: {
+      external: ["ts-custom-error"],
+      output: {
+        globals: {
+          "ts-custom-error": "ts-custom-error",
+        },
+      },
+    },
+    sourcemap: true,
+  },
+  define: {
+    "process.env": process.env,
+  },
+  resolve: {
+    preserveSymlinks: true,
+    alias: {
+      "@": resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@react-router/serve':
         specifier: ^7.4.0
         version: 7.4.0(react-router@7.4.0)(typescript@5.7.3)
+      '@repo/api':
+        specifier: workspace:^
+        version: link:../../packages/api
       '@repo/design-system':
         specifier: workspace:^
         version: link:../../packages/design-system
@@ -123,6 +126,9 @@ importers:
       '@react-router/serve':
         specifier: ^7.4.0
         version: 7.4.0(react-router@7.4.0)(typescript@5.7.3)
+      '@repo/api':
+        specifier: workspace:^
+        version: link:../../packages/api
       '@repo/design-system':
         specifier: workspace:*
         version: link:../../packages/design-system
@@ -223,6 +229,31 @@ importers:
       vitest:
         specifier: ^3.0.9
         version: 3.0.9(@types/node@22.13.14)(jsdom@26.0.0)
+
+  packages/api:
+    dependencies:
+      ts-custom-error:
+        specifier: ^3.3.1
+        version: 3.3.1
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.13.14
+        version: 22.13.14
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
+      vite:
+        specifier: ^6.2.3
+        version: 6.2.3(@types/node@22.13.14)
+      vite-plugin-dts:
+        specifier: ^4.5.3
+        version: 4.5.3(@types/node@22.13.14)(typescript@5.8.2)(vite@6.2.3)
 
   packages/design-system:
     dependencies:
@@ -1250,6 +1281,50 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+    dev: true
+
+  /@microsoft/api-extractor-model@7.30.5(@types/node@22.13.14):
+    resolution: {integrity: sha512-0ic4rcbcDZHz833RaTZWTGu+NpNgrxVNjVaor0ZDUymfDFzjA/Uuk8hYziIUIOEOSTfmIQqyzVwlzxZxPe7tOA==}
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.13.0(@types/node@22.13.14)
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
+  /@microsoft/api-extractor@7.52.2(@types/node@22.13.14):
+    resolution: {integrity: sha512-RX37V5uhBBPUvrrcmIxuQ8TPsohvr6zxo7SsLPOzBYcH9nbjbvtdXrts4cxHCXGOin9JR5ar37qfxtCOuEBTHA==}
+    hasBin: true
+    dependencies:
+      '@microsoft/api-extractor-model': 7.30.5(@types/node@22.13.14)
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.13.0(@types/node@22.13.14)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.15.2(@types/node@22.13.14)
+      '@rushstack/ts-command-line': 4.23.7(@types/node@22.13.14)
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      resolve: 1.22.10
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
+  /@microsoft/tsdoc-config@0.17.1:
+    resolution: {integrity: sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==}
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      ajv: 8.12.0
+      jju: 1.4.0
+      resolve: 1.22.10
+    dev: true
+
+  /@microsoft/tsdoc@0.15.1:
+    resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
     dev: true
 
   /@mjackson/node-fetch-server@0.2.0:
@@ -2402,6 +2477,20 @@ packages:
       - supports-color
       - typescript
 
+  /@rollup/pluginutils@5.1.4:
+    resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.7
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    dev: true
+
   /@rollup/rollup-android-arm-eabi@4.37.0:
     resolution: {integrity: sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==}
     cpu: [arm]
@@ -2557,6 +2646,56 @@ packages:
     os: [win32]
     requiresBuild: true
     optional: true
+
+  /@rushstack/node-core-library@5.13.0(@types/node@22.13.14):
+    resolution: {integrity: sha512-IGVhy+JgUacAdCGXKUrRhwHMTzqhWwZUI+qEPcdzsb80heOw0QPbhhoVsoiMF7Klp8eYsp7hzpScMXmOa3Uhfg==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+    dependencies:
+      '@types/node': 22.13.14
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.10
+      semver: 7.5.4
+    dev: true
+
+  /@rushstack/rig-package@0.5.3:
+    resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
+    dependencies:
+      resolve: 1.22.10
+      strip-json-comments: 3.1.1
+    dev: true
+
+  /@rushstack/terminal@0.15.2(@types/node@22.13.14):
+    resolution: {integrity: sha512-7Hmc0ysK5077R/IkLS9hYu0QuNafm+TbZbtYVzCMbeOdMjaRboLKrhryjwZSRJGJzu+TV1ON7qZHeqf58XfLpA==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+    dependencies:
+      '@rushstack/node-core-library': 5.13.0(@types/node@22.13.14)
+      '@types/node': 22.13.14
+      supports-color: 8.1.1
+    dev: true
+
+  /@rushstack/ts-command-line@4.23.7(@types/node@22.13.14):
+    resolution: {integrity: sha512-Gr9cB7DGe6uz5vq2wdr89WbVDKz0UeuFEn5H2CfWDe7JvjFFaiV15gi6mqDBTbHhHCWS7w8mF1h3BnIfUndqdA==}
+    dependencies:
+      '@rushstack/terminal': 0.15.2(@types/node@22.13.14)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
 
   /@standard-schema/utils@0.3.0:
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -2893,6 +3032,10 @@ packages:
       '@testing-library/dom': 10.4.0
     dev: true
 
+  /@types/argparse@1.0.38:
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+    dev: true
+
   /@types/aria-query@5.0.4:
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
     dev: true
@@ -3130,6 +3273,71 @@ packages:
       tinyrainbow: 2.0.0
     dev: true
 
+  /@volar/language-core@2.4.12:
+    resolution: {integrity: sha512-RLrFdXEaQBWfSnYGVxvR2WrO6Bub0unkdHYIdC31HzIEqATIuuhRRzYu76iGPZ6OtA4Au1SnW0ZwIqPP217YhA==}
+    dependencies:
+      '@volar/source-map': 2.4.12
+    dev: true
+
+  /@volar/source-map@2.4.12:
+    resolution: {integrity: sha512-bUFIKvn2U0AWojOaqf63ER0N/iHIBYZPpNGogfLPQ68F5Eet6FnLlyho7BS0y2HJ1jFhSif7AcuTx1TqsCzRzw==}
+    dev: true
+
+  /@volar/typescript@2.4.12:
+    resolution: {integrity: sha512-HJB73OTJDgPc80K30wxi3if4fSsZZAOScbj2fcicMuOPoOkcf9NNAINb33o+DzhBdF9xTKC1gnPmIRDous5S0g==}
+    dependencies:
+      '@volar/language-core': 2.4.12
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+    dev: true
+
+  /@vue/compiler-core@3.5.13:
+    resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@vue/shared': 3.5.13
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+    dev: true
+
+  /@vue/compiler-dom@3.5.13:
+    resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
+    dependencies:
+      '@vue/compiler-core': 3.5.13
+      '@vue/shared': 3.5.13
+    dev: true
+
+  /@vue/compiler-vue2@2.7.16:
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+    dev: true
+
+  /@vue/language-core@2.2.0(typescript@5.8.2):
+    resolution: {integrity: sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@volar/language-core': 2.4.12
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.13
+      alien-signals: 0.4.14
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      typescript: 5.8.2
+    dev: true
+
+  /@vue/shared@3.5.13:
+    resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+    dev: true
+
   /abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -3159,6 +3367,28 @@ packages:
     engines: {node: '>= 14'}
     dev: true
 
+  /ajv-draft-04@1.0.0(ajv@8.13.0):
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.13.0
+    dev: true
+
+  /ajv-formats@3.0.1(ajv@8.13.0):
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.13.0
+    dev: true
+
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -3166,6 +3396,28 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  /ajv@8.12.0:
+    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+    dev: true
+
+  /ajv@8.13.0:
+    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+    dev: true
+
+  /alien-signals@0.4.14:
+    resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
+    dev: true
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3195,6 +3447,12 @@ packages:
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+    dev: true
+
+  /argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
     dev: true
 
   /argparse@2.0.1:
@@ -3451,6 +3709,10 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+    dev: true
+
   /compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -3482,6 +3744,14 @@ packages:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
+    dev: true
+
+  /confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+    dev: true
+
+  /confbox@0.2.1:
+    resolution: {integrity: sha512-hkT3yDPFbs95mNCy1+7qNKC6Pro+/ibzYxtM2iqEigpf0sVw+bg4Zh9/snjsBcf990vfIsg5+1U7VyiyBb3etg==}
     dev: true
 
   /config-chain@1.1.13:
@@ -3653,6 +3923,10 @@ packages:
   /dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
     dev: false
+
+  /de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
+    dev: true
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3995,6 +4269,10 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
@@ -4056,6 +4334,10 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  /exsolve@1.0.4:
+    resolution: {integrity: sha512-xsZH6PXaER4XoV+NiT7JHp1bJodJVT+cxeSH1G0f0tlT0lJqYuHUP3bUx2HtfTDvOagMINYp8rsqusxud3RXhw==}
+    dev: true
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4187,6 +4469,15 @@ packages:
       universalify: 2.0.1
     dev: true
 
+  /fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+    dev: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4302,6 +4593,11 @@ packages:
     dependencies:
       function-bind: 1.1.2
 
+  /he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+    dev: true
+
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -4383,6 +4679,11 @@ packages:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  /import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
+    dev: true
+
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -4456,6 +4757,10 @@ packages:
   /jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  /jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+    dev: true
 
   /js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
@@ -4540,6 +4845,10 @@ packages:
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  /json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    dev: true
+
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -4561,6 +4870,10 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
+
+  /kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+    dev: true
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -4670,6 +4983,15 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
+  /local-pkg@1.1.1:
+    resolution: {integrity: sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.7.4
+      pkg-types: 2.1.0
+      quansync: 0.2.10
+    dev: true
+
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -4702,6 +5024,13 @@ packages:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
       yallist: 3.1.1
+    dev: true
+
+  /lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
     dev: true
 
   /lru-cache@7.18.3:
@@ -4775,6 +5104,12 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  /minimatch@3.0.8:
+    resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -4796,6 +5131,15 @@ packages:
   /minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+    dev: true
+
+  /mlly@1.7.4:
+    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
+    dependencies:
+      acorn: 8.14.1
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.5.4
     dev: true
 
   /morgan@1.10.0:
@@ -4830,6 +5174,10 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  /muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+    dev: true
 
   /nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -4987,6 +5335,10 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  /path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: true
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -5035,6 +5387,27 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
     dev: false
+
+  /picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.7.4
+      pathe: 2.0.3
+    dev: true
+
+  /pkg-types@2.1.0:
+    resolution: {integrity: sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==}
+    dependencies:
+      confbox: 0.2.1
+      exsolve: 1.0.4
+      pathe: 2.0.3
+    dev: true
 
   /postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -5123,6 +5496,10 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.1.0
+
+  /quansync@0.2.10:
+    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
+    dev: true
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5365,6 +5742,11 @@ packages:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
     dev: true
 
+  /require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -5450,6 +5832,14 @@ packages:
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+    dev: true
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
     dev: true
 
   /semver@7.7.1:
@@ -5590,6 +5980,10 @@ packages:
     resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
     dev: true
 
+  /sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
+
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
@@ -5604,6 +5998,11 @@ packages:
 
   /stream-slice@0.1.2:
     resolution: {integrity: sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==}
+
+  /string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+    dev: true
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5656,6 +6055,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
+
+  /supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -5743,6 +6149,11 @@ packages:
       typescript: '>=4.8.4'
     dependencies:
       typescript: 5.8.2
+    dev: false
+
+  /ts-custom-error@3.3.1:
+    resolution: {integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==}
+    engines: {node: '>=14.0.0'}
     dev: false
 
   /tslib@2.8.1:
@@ -5857,6 +6268,10 @@ packages:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /ufo@1.5.4:
+    resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
+    dev: true
 
   /undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
@@ -6009,6 +6424,32 @@ packages:
       - yaml
     dev: true
 
+  /vite-plugin-dts@4.5.3(@types/node@22.13.14)(typescript@5.8.2)(vite@6.2.3):
+    resolution: {integrity: sha512-P64VnD00dR+e8S26ESoFELqc17+w7pKkwlBpgXteOljFyT0zDwD8hH4zXp49M/kciy//7ZbVXIwQCekBJjfWzA==}
+    peerDependencies:
+      typescript: '*'
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      '@microsoft/api-extractor': 7.52.2(@types/node@22.13.14)
+      '@rollup/pluginutils': 5.1.4
+      '@volar/typescript': 2.4.12
+      '@vue/language-core': 2.2.0(typescript@5.8.2)
+      compare-versions: 6.1.1
+      debug: 4.4.0
+      kolorist: 1.8.0
+      local-pkg: 1.1.1
+      magic-string: 0.30.17
+      typescript: 5.8.2
+      vite: 6.2.3(@types/node@22.13.14)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
+    dev: true
+
   /vite@6.2.3(@types/node@22.13.14):
     resolution: {integrity: sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -6121,6 +6562,10 @@ packages:
       - yaml
     dev: true
 
+  /vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+    dev: true
+
   /w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -6228,6 +6673,10 @@ packages:
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    dev: true
+
+  /yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
   /yaml@1.10.2:


### PR DESCRIPTION
## 요약

- [API 명세서](https://www.notion.so/API-1bb4873f28dd80d2a052ccc0ba487727?pvs=4)의 명세대로 요청을 수행하는 api fetcher 를 작성하였습니다.

## 작업 내용

- [feat: 디멘터 api fetch client를 제공하는 @repo/api 패키지 추가](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/17/commits/a9abba6a72efeb88466d8982ae3430cffa852cdd)
- [config: cSpell.words 목록 추가](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/17/commits/b7ed0440628e5170f72bf327519ea8a0c40796d3)
