### PR TITLE
[Alang-27] 로그인, 로그아웃, 내 정보 조회 API 연동

### DIFF
--- a/apps/service/src/features/auth/hooks/use-auth.ts
+++ b/apps/service/src/features/auth/hooks/use-auth.ts
@@ -1,3 +1,4 @@
+import { handleError } from "@/app/error-handler/error-handler";
 import { useLogin } from "@/features/auth/hooks/use-login";
 import { useLogout } from "@/features/auth/hooks/use-logout";
 import { useGetUserInfo } from "@/pages/my/hooks/useGetUserInfo";
@@ -8,21 +9,20 @@ import { useNavigate } from "react-router";
 export function useAuth() {
   const navigate = useNavigate();
 
-  const { data: user, refetch, DEV_setIsLoggedIn } = useGetUserInfo();
+  const { data: user, refetch } = useGetUserInfo();
   const isAuthenticated = useMemo(() => user !== null, [user]);
 
   const { login } = useLogin({
     onLoginSuccess: () => {
-      DEV_setIsLoggedIn(true);
       refetch();
     },
     onLoginFailure: (error) => {
-      console.error(error);
+      handleError(error);
+      throw error;
     },
   });
   const { logout: handleLogout } = useLogout({
     onLogoutSuccess: () => {
-      DEV_setIsLoggedIn(false);
       refetch();
       navigate(ROUTE_PATH.HOME);
     },

--- a/apps/service/src/features/auth/hooks/use-login.ts
+++ b/apps/service/src/features/auth/hooks/use-login.ts
@@ -1,3 +1,5 @@
+import { dementorApiFetchers } from "@repo/api";
+
 export interface UseLoginProps {
   onLoginSuccess?: () => void;
   onLoginFailure?: (error: Error) => void;
@@ -7,7 +9,13 @@ export function useLogin({ onLoginSuccess, onLoginFailure }: UseLoginProps) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleLogin = async (email: string, password: string) => {
     try {
-      //  TODO: 로그인 API 호출
+      await dementorApiFetchers.auth.login({
+        queryParam: {
+          email,
+          password,
+        },
+      });
+
       onLoginSuccess?.();
     } catch (error) {
       if (error instanceof Error) {

--- a/apps/service/src/features/auth/hooks/use-logout.ts
+++ b/apps/service/src/features/auth/hooks/use-logout.ts
@@ -1,3 +1,5 @@
+import { dementorApiFetchers } from "@repo/api";
+
 export interface UseLogoutProps {
   onLogoutSuccess?: () => void;
   onLogoutFailure?: (error: Error) => void;
@@ -9,7 +11,7 @@ export function useLogout({
 }: UseLogoutProps) {
   const handleLogout = async () => {
     try {
-      //  TODO: 로그아웃 API 호출
+      await dementorApiFetchers.auth.logout();
       onLogoutSuccess?.();
     } catch (error) {
       if (error instanceof Error) {

--- a/apps/service/src/pages/my/hooks/useGetUserInfo.ts
+++ b/apps/service/src/pages/my/hooks/useGetUserInfo.ts
@@ -1,32 +1,30 @@
+"use client";
+
 import { ModelCreator } from "@/entities/model/model-creator";
 import { UserModel } from "@/entities/model/user/user.model";
+import { dementorApiFetchers } from "@repo/api";
 import { useSuspenseQuery } from "@tanstack/react-query";
-
-const MOCK_USER_DATA = {
-  id: "1",
-  email: "example@email.com",
-  nickname: "홍길동",
-  createdAt: "2024-03-28T00:00:00.000Z",
-};
-
-let MOCK_IS_LOGGED_IN = false;
 
 export function useGetUserInfo() {
   const query = useSuspenseQuery({
     queryKey: ["user-info"],
     queryFn: async () => {
-      if (MOCK_IS_LOGGED_IN) {
-        return MOCK_USER_DATA;
-      } else {
+      try {
+        const response = await dementorApiFetchers.member.getMyMemberInfo();
+        return response.data;
+      } catch {
         return null;
       }
     },
-    select: (data) => data && ModelCreator.create(UserModel, data),
+    select: (data) =>
+      data &&
+      ModelCreator.create(UserModel, {
+        id: data.id,
+        createdAt: data.created_at,
+        email: data.email,
+        nickname: data.nickname,
+      }),
   });
 
-  const DEV_setIsLoggedIn = (isLoggedIn: boolean) => {
-    MOCK_IS_LOGGED_IN = isLoggedIn;
-  };
-
-  return { ...query, DEV_setIsLoggedIn };
+  return { ...query };
 }

--- a/apps/service/src/widgets/auth/login-form.tsx
+++ b/apps/service/src/widgets/auth/login-form.tsx
@@ -20,17 +20,7 @@ const loginFormSchema = z.object({
   email: z.string().email({
     message: "이메일 형식이 올바르지 않습니다.",
   }),
-  password: z
-    .string()
-    .min(8, {
-      message: "비밀번호는 8자 이상이어야 합니다.",
-    })
-    .max(16, {
-      message: "비밀번호는 16자 이하여야 합니다.",
-    })
-    .regex(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/, {
-      message: "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.",
-    }),
+  password: z.string().nonempty(),
 });
 
 export type LoginFormData = z.infer<typeof loginFormSchema>;

--- a/apps/service/test/widgets/auth/login-form.test.tsx
+++ b/apps/service/test/widgets/auth/login-form.test.tsx
@@ -37,28 +37,6 @@ describe("LoginForm", () => {
     });
   });
 
-  test("비밀번호 길이 유효성 검사", async () => {
-    const passwordInput = screen.getByLabelText("비밀번호");
-    fireEvent.change(passwordInput, { target: { value: "short1!" } });
-    fireEvent.blur(passwordInput);
-
-    await waitFor(() => {
-      expect(screen.getByText("비밀번호는 8자 이상이어야 합니다."));
-    });
-  });
-
-  test("비밀번호 형식 유효성 검사", async () => {
-    const passwordInput = screen.getByLabelText("비밀번호");
-    fireEvent.change(passwordInput, { target: { value: "password12345" } });
-    fireEvent.blur(passwordInput);
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
-      );
-    });
-  });
-
   test("유효한 데이터로 폼 제출 시 onSubmit 함수 호출", async () => {
     const emailInput = screen.getByLabelText("이메일");
     const passwordInput = screen.getByLabelText("비밀번호");

--- a/packages/api/src/fetchers/auth/fetchers.ts
+++ b/packages/api/src/fetchers/auth/fetchers.ts
@@ -7,7 +7,7 @@ export const signUp = generateServiceFetcher<
   SignUpRequest,
   ServerSuccessResponse<{ message: string }>
 >({
-  endpoint: "/api/signup",
+  endpoint: "/api/members",
   method: "POST",
 });
 
@@ -17,7 +17,7 @@ export const validateEmail = generateServiceFetcher<
   void,
   ServerSuccessResponse<{ isEmail: boolean }>
 >({
-  endpoint: "/api/signup/isEmail",
+  endpoint: "/api/members/isEmail",
   method: "GET",
 });
 
@@ -27,7 +27,7 @@ export const requestSignUpVerifyCode = generateServiceFetcher<
   void,
   null
 >({
-  endpoint: "/api/signup/verifyCode",
+  endpoint: "/api/members/verifyCode",
   method: "POST",
 });
 
@@ -37,7 +37,7 @@ export const verifySignUpVerifyCode = generateServiceFetcher<
   void,
   { verifyEmail: boolean }
 >({
-  endpoint: "/api/signup/verifyEmail",
+  endpoint: "/api/members/verifyEmail",
   method: "GET",
 });
 
@@ -47,7 +47,7 @@ export const validateNickname = generateServiceFetcher<
   void,
   ServerSuccessResponse<{ isNickname: boolean }>
 >({
-  endpoint: "/api/signup/isNickname",
+  endpoint: "/api/members/isNickname",
   method: "GET",
 });
 
@@ -57,7 +57,7 @@ export const login = generateServiceFetcher<
   void,
   null
 >({
-  endpoint: "/api/login",
+  endpoint: "/api/members/login",
   method: "POST",
 });
 
@@ -67,6 +67,6 @@ export const logout = generateServiceFetcher<
   void,
   { message: string }
 >({
-  endpoint: "/api/logout",
+  endpoint: "/api/members/logout",
   method: "POST",
 });

--- a/packages/api/src/fetchers/member/fetchers.ts
+++ b/packages/api/src/fetchers/member/fetchers.ts
@@ -11,7 +11,7 @@ export const getMyMemberInfo = generateServiceFetcher<
   void,
   ServerSuccessResponse<GetMyMemberInfoResponse>
 >({
-  endpoint: "/api/member/me",
+  endpoint: "/api/members/info",
   method: "GET",
 });
 


### PR DESCRIPTION
## 요약

로그인, 로그아웃, 내 정보 조회 API를 연동합니다.

## 작업 내용

- [feat: API 인터페이스 변경에 맞게 fetcher 수정](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/20/commits/08ffc160a960d046310c697052a4d3c8c23c13f5)
- [fix: 로그인 시 비밀번호 validate 제거](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/20/commits/2a33610fbe1edf9ce3f9bb9dfc8711f32ba56344)
- [feat: 로그인, 로그아웃, 내 정보 조회 API 연동](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/20/commits/df6c0c33435bafae2c2e21759af517e69c68daa6)
- [test: 변경된 시나리오에 따른 테스트 코드 제거](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/20/commits/67b5c61ec04a43997e47187e44267a427ed7995a)

