### PR TITLE
[Alang-34] 관리자 페이지에서 멘토 정보 수정 요청에 대한 상세보기 기능 제공

### DIFF
--- a/apps/admin/src/features/mentor-modification-request/use-get-mentor-info-modification-requests.ts
+++ b/apps/admin/src/features/mentor-modification-request/use-get-mentor-info-modification-requests.ts
@@ -1,0 +1,80 @@
+import { DateFormatter } from "@/shared/date/date-formatter";
+import { dementorApiFetchers } from "@repo/api";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+// Status 타입 직접 정의
+type Status = "PENDING" | "APPROVED" | "REJECTED";
+
+export interface ModificationRequestField {
+  before: string | number;
+  after: string | number;
+}
+
+export interface ModificationRequest {
+  requestId: number;
+  status: Status;
+  requestDate: DateFormatter;
+  modifiedFields: {
+    career?: ModificationRequestField;
+    currentCompany?: ModificationRequestField;
+    introduction?: ModificationRequestField;
+    jobId?: ModificationRequestField;
+    attachments?: {
+      attachmentId?: number;
+      fileName?: string;
+      fileUrl?: string;
+    }[];
+  };
+}
+
+export interface UseGetMentorInfoModificationRequestOptions {
+  memberId: number;
+  proposalId: number;
+}
+
+export function useGetMentorInfoModificationRequest({
+  memberId,
+  proposalId,
+}: UseGetMentorInfoModificationRequestOptions) {
+  const query = useSuspenseQuery({
+    queryKey: ["mentor-info-modification-requests", memberId, proposalId],
+    queryFn: async () => {
+      return dementorApiFetchers.mentor.getMentorInfoModificationRequestList({
+        pathParams: {
+          memberId: memberId.toString(),
+        },
+        queryParam: {
+          proposalId,
+        },
+      });
+    },
+    select: (response) => {
+      if (!response || !response.data) {
+        return null;
+      }
+
+      const { data } = response;
+
+      const requests = data.modificationRequests.map((request) => ({
+        requestId: request.proposalId,
+        status: request.status,
+        requestDate: new DateFormatter(request.createdAt),
+        modifiedFields: {
+          career: request.modifiedFields.career,
+          currentCompany: request.modifiedFields.currentCompany,
+          introduction: request.modifiedFields.introduction,
+          jobId: request.modifiedFields.jobId,
+          attachments: Array.isArray(request.attachments)
+            ? request.attachments.length > 0
+              ? request.attachments
+              : null
+            : null,
+        },
+      }));
+
+      return requests[0];
+    },
+  });
+
+  return query;
+}

--- a/apps/admin/src/pages/apply-approval/components/apply-item.tsx
+++ b/apps/admin/src/pages/apply-approval/components/apply-item.tsx
@@ -1,4 +1,5 @@
 import { ApprovalRequestModel } from "@/entities/approval/approval-request.model";
+import { MentorModificationDetailModal } from "@/pages/apply-approval/components/mentor-modification-detail-modal";
 import { StatusConst } from "@repo/api";
 import {
   Badge,
@@ -85,15 +86,13 @@ export function ApplyItem({ applicant, onApprove, onReject }: ApplyItemProps) {
               <p className="text-sm font-medium">{applicant.mentor.name}</p>
             </div>
             <div className="flex gap-2 items-center">
-              {isApprovalCategory && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleOpenDetailModal}
-                >
-                  상세 보기
-                </Button>
-              )}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleOpenDetailModal}
+              >
+                상세 보기
+              </Button>
               {isPending && (
                 <>
                   <Button variant="outline" onClick={onReject}>
@@ -107,11 +106,18 @@ export function ApplyItem({ applicant, onApprove, onReject }: ApplyItemProps) {
         </CardContent>
       </Card>
 
-      {isApprovalCategory && (
+      {isApprovalCategory ? (
         <ApplyDetailModal
           isOpen={isDetailModalOpen}
           onClose={handleCloseDetailModal}
           applymentId={applicant.memberId}
+        />
+      ) : (
+        <MentorModificationDetailModal
+          isOpen={isDetailModalOpen}
+          onClose={handleCloseDetailModal}
+          memberId={applicant.memberId}
+          proposalId={applicant.id}
         />
       )}
     </>

--- a/apps/admin/src/pages/apply-approval/components/mentor-modification-detail-modal.tsx
+++ b/apps/admin/src/pages/apply-approval/components/mentor-modification-detail-modal.tsx
@@ -1,0 +1,428 @@
+import { useGetMentorInfoModificationRequest } from "@/features/mentor-modification-request/use-get-mentor-info-modification-requests";
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  toast,
+} from "@repo/ui";
+import { Download, FileText } from "lucide-react";
+import { Suspense, useState } from "react";
+
+interface MentorModificationDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  memberId: number;
+  proposalId: number;
+}
+
+export function MentorModificationDetailModal({
+  isOpen,
+  onClose,
+  memberId,
+  proposalId,
+}: MentorModificationDetailModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[700px] max-h-[90vh] overflow-y-auto w-[92vw] p-3 sm:p-6 max-w-full">
+        <DialogHeader>
+          <DialogTitle>멘토 정보 수정 요청 내역</DialogTitle>
+          <DialogDescription>
+            멘토 정보 수정 요청 목록과 처리 상태를 확인할 수 있습니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Suspense fallback={<ModificationRequestsLoadingSkeleton />}>
+          <ModificationRequestsContent
+            memberId={memberId}
+            proposalId={proposalId}
+          />
+        </Suspense>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ModificationRequestsContentProps {
+  memberId: number;
+  proposalId: number;
+}
+
+function ModificationRequestsContent({
+  memberId,
+  proposalId,
+}: ModificationRequestsContentProps) {
+  const { data } = useGetMentorInfoModificationRequest({
+    memberId,
+    proposalId,
+  });
+
+  return (
+    <div>
+      <div className="rounded-md border overflow-x-auto">
+        <Table className="min-w-full">
+          <TableBody>{data && <RequestRow request={data} />}</TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+interface RequestRowProps {
+  request: NonNullable<
+    Awaited<ReturnType<typeof useGetMentorInfoModificationRequest>>["data"]
+  >;
+}
+
+function RequestRow({ request }: RequestRowProps) {
+  const [detailOpen, setDetailOpen] = useState(true);
+
+  // 파일 다운로드 처리 함수
+  const handleDownload = async (fileUrl: string, fileName: string) => {
+    try {
+      const fullUrl = `${import.meta.env.VITE_API_URL}${fileUrl}`;
+      const response = await fetch(fullUrl, {
+        method: "GET",
+        credentials: "include", // 쿠키를 포함하여 요청
+      });
+
+      if (!response.ok) {
+        throw new Error("파일 다운로드에 실패했습니다.");
+      }
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+
+      // 리소스 정리
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(link);
+
+      toast.success("파일 다운로드가 완료되었습니다.");
+    } catch (error) {
+      console.error("파일 다운로드 오류:", error);
+      toast.error("파일 다운로드에 실패했습니다.");
+    }
+  };
+
+  // 수정된 필드들을 문자열로 변환
+  const modifiedFieldsText = Object.keys(request.modifiedFields)
+    .filter(
+      (key) =>
+        !!request.modifiedFields[key as keyof typeof request.modifiedFields]
+    )
+    .map((key) => {
+      switch (key) {
+        case "career":
+          return "경력";
+        case "currentCompany":
+          return "직장";
+        case "introduction":
+          return "소개";
+        case "jobId":
+          return "직무";
+        case "attachments":
+          return "첨부파일";
+        default:
+          return key;
+      }
+    })
+    .join(", ");
+
+  // 파일명 축약 함수
+  const truncateFileName = (fileName: string, maxLength: number = 40) => {
+    if (!fileName) return "파일명 없음";
+    if (fileName.length <= maxLength) return fileName;
+
+    const extension =
+      fileName.lastIndexOf(".") > 0
+        ? fileName.substring(fileName.lastIndexOf("."))
+        : "";
+
+    const nameWithoutExt = fileName.substring(
+      0,
+      fileName.lastIndexOf(".") > 0
+        ? fileName.lastIndexOf(".")
+        : fileName.length
+    );
+    const truncatedName =
+      nameWithoutExt.substring(0, maxLength - 3 - extension.length) + "...";
+
+    return truncatedName + extension;
+  };
+
+  return (
+    <>
+      <TableRow>
+        <TableCell className="text-xs sm:text-sm py-2 sm:py-4">
+          {request.requestDate.date}
+        </TableCell>
+        <TableCell className="text-xs sm:text-sm py-2 sm:py-4">
+          {modifiedFieldsText}
+        </TableCell>
+        <TableCell className="text-right text-xs sm:text-sm py-2 sm:py-4">
+          <StatusBadge status={request.status} />
+        </TableCell>
+        <TableCell className="py-2 sm:py-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setDetailOpen(!detailOpen)}
+            className="p-1 sm:p-2"
+          >
+            <FileText className="h-3 w-3 sm:h-4 sm:w-4" />
+          </Button>
+        </TableCell>
+      </TableRow>
+
+      {detailOpen && (
+        <TableRow>
+          <TableCell colSpan={4} className="bg-muted/20 p-2 sm:p-4">
+            <div className="overflow-x-auto">
+              <h4 className="font-medium mb-2 sm:mb-3 text-sm sm:text-base">
+                수정 상세 내역
+              </h4>
+
+              {request.modifiedFields.jobId && (
+                <div className="mb-2 sm:mb-3">
+                  <div className="font-medium mb-1 text-xs sm:text-sm">
+                    직무
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <div className="p-2 bg-muted/30 rounded-md">
+                      <div className="text-xs text-muted-foreground mb-1">
+                        이전
+                      </div>
+                      <div className="text-xs sm:text-sm">
+                        {request.modifiedFields.jobId.before}
+                      </div>
+                    </div>
+                    <div className="p-2 bg-muted/30 rounded-md">
+                      <div className="text-xs text-muted-foreground mb-1">
+                        변경
+                      </div>
+                      <div className="text-xs sm:text-sm">
+                        {request.modifiedFields.jobId.after}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {request.modifiedFields.career && (
+                <div className="mb-2 sm:mb-3">
+                  <div className="font-medium mb-1 text-xs sm:text-sm">
+                    경력
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <div className="p-2 bg-muted/30 rounded-md">
+                      <div className="text-xs text-muted-foreground mb-1">
+                        이전
+                      </div>
+                      <div className="text-xs sm:text-sm">
+                        {request.modifiedFields.career.before}년
+                      </div>
+                    </div>
+                    <div className="p-2 bg-muted/30 rounded-md">
+                      <div className="text-xs text-muted-foreground mb-1">
+                        변경
+                      </div>
+                      <div className="text-xs sm:text-sm">
+                        {request.modifiedFields.career.after}년
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {request.modifiedFields.currentCompany && (
+                <div className="mb-2 sm:mb-3">
+                  <div className="font-medium mb-1 text-xs sm:text-sm">
+                    현재 직장
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <div className="p-2 bg-muted/30 rounded-md">
+                      <div className="text-xs text-muted-foreground mb-1">
+                        이전
+                      </div>
+                      <div className="text-xs sm:text-sm">
+                        {request.modifiedFields.currentCompany.before}
+                      </div>
+                    </div>
+                    <div className="p-2 bg-muted/30 rounded-md">
+                      <div className="text-xs text-muted-foreground mb-1">
+                        변경
+                      </div>
+                      <div className="text-xs sm:text-sm">
+                        {request.modifiedFields.currentCompany.after}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {request.modifiedFields.introduction && (
+                <div className="mb-2 sm:mb-3">
+                  <div className="font-medium mb-1 text-xs sm:text-sm">
+                    소개
+                  </div>
+                  <div className="grid grid-cols-1 gap-2">
+                    <div className="p-2 bg-muted/30 rounded-md">
+                      <div className="text-xs text-muted-foreground mb-1">
+                        이전
+                      </div>
+                      <div className="whitespace-pre-wrap text-xs sm:text-sm">
+                        {request.modifiedFields.introduction.before}
+                      </div>
+                    </div>
+                    <div className="p-2 bg-muted/30 rounded-md">
+                      <div className="text-xs text-muted-foreground mb-1">
+                        변경
+                      </div>
+                      <div className="whitespace-pre-wrap text-xs sm:text-sm">
+                        {request.modifiedFields.introduction.after}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {request.modifiedFields.attachments &&
+                request.modifiedFields.attachments.length > 0 && (
+                  <div>
+                    <div className="font-medium mb-1 text-xs sm:text-sm">
+                      첨부파일
+                    </div>
+                    <div className="p-2 bg-muted/30 rounded-md">
+                      <div className="space-y-2">
+                        {request.modifiedFields.attachments.map(
+                          (attachment, index) => (
+                            <div
+                              key={index}
+                              className="flex flex-col sm:flex-row sm:items-center border-b pb-2 last:border-0 break-all"
+                            >
+                              <div className="min-w-0 w-full mb-2 sm:mb-0 sm:mr-2">
+                                <span
+                                  className="text-xs sm:text-sm block truncate"
+                                  title={attachment.fileName || "파일명 없음"}
+                                >
+                                  {truncateFileName(
+                                    attachment.fileName || "파일명 없음",
+                                    40
+                                  )}
+                                </span>
+                              </div>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() =>
+                                  handleDownload(
+                                    attachment.fileUrl ?? "",
+                                    attachment.fileName || `file-${index}`
+                                  )
+                                }
+                                className="flex items-center justify-center gap-1 shrink-0 text-xs h-8 w-full sm:w-auto"
+                              >
+                                <Download className="h-3 w-3" />
+                                <span>다운로드</span>
+                              </Button>
+                            </div>
+                          )
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )}
+            </div>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case "APPROVED":
+      return (
+        <Badge
+          variant="outline"
+          className="bg-green-50 text-green-700 hover:bg-green-50 border-green-200 text-xs px-1.5 py-0 sm:px-2 sm:py-0.5"
+        >
+          승인됨
+        </Badge>
+      );
+    case "REJECTED":
+      return (
+        <Badge
+          variant="outline"
+          className="bg-red-50 text-red-700 hover:bg-red-50 border-red-200 text-xs px-1.5 py-0 sm:px-2 sm:py-0.5"
+        >
+          거절됨
+        </Badge>
+      );
+    case "PENDING":
+    default:
+      return (
+        <Badge
+          variant="outline"
+          className="bg-yellow-50 text-yellow-700 hover:bg-yellow-50 border-yellow-200 text-xs px-1.5 py-0 sm:px-2 sm:py-0.5"
+        >
+          대기중
+        </Badge>
+      );
+  }
+}
+
+function ModificationRequestsLoadingSkeleton() {
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[90px] sm:w-[100px] text-xs sm:text-sm">
+              요청 날짜
+            </TableHead>
+            <TableHead className="text-xs sm:text-sm">수정된 항목</TableHead>
+            <TableHead className="w-[80px] sm:w-[100px] text-right text-xs sm:text-sm">
+              상태
+            </TableHead>
+            <TableHead className="w-[50px] sm:w-[80px]"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <TableRow key={i}>
+              <TableCell>
+                <Skeleton className="h-3 sm:h-4 w-16 sm:w-24 bg-muted/30" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-3 sm:h-4 w-24 sm:w-32 bg-muted/30" />
+              </TableCell>
+              <TableCell className="text-right">
+                <Skeleton className="h-4 sm:h-6 w-12 sm:w-16 ml-auto bg-muted/30" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-6 sm:h-8 w-6 sm:w-8 bg-muted/30" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/admin/src/pages/apply-approval/components/modification-detail-modal.tsx
+++ b/apps/admin/src/pages/apply-approval/components/modification-detail-modal.tsx
@@ -1,0 +1,208 @@
+import { useGetMentorInfoModificationRequest } from "@/features/mentor-modification-request/use-get-mentor-info-modification-requests";
+import { StatusConst } from "@repo/api";
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Skeleton,
+} from "@repo/ui";
+import MDEditor from "@uiw/react-md-editor";
+
+interface ModificationDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  memberId: number;
+  proposalId: number;
+}
+
+export function ModificationDetailModal({
+  isOpen,
+  onClose,
+  memberId,
+  proposalId,
+}: ModificationDetailModalProps) {
+  const { data, isLoading } = useGetMentorInfoModificationRequest({
+    memberId,
+    proposalId,
+  });
+
+  const getStatusBadge = (status?: string) => {
+    switch (status) {
+      case StatusConst.APPROVED:
+        return (
+          <Badge
+            variant="outline"
+            className="bg-green-100 text-green-800 border-green-300"
+          >
+            승인됨
+          </Badge>
+        );
+      case StatusConst.REJECTED:
+        return (
+          <Badge
+            variant="outline"
+            className="bg-red-100 text-red-800 border-red-300"
+          >
+            거절됨
+          </Badge>
+        );
+      default:
+        return (
+          <Badge
+            variant="outline"
+            className="bg-yellow-100 text-yellow-800 border-yellow-300"
+          >
+            대기중
+          </Badge>
+        );
+    }
+  };
+
+  const handleDownload = async (fileUrl: string, fileName: string) => {
+    try {
+      const fullUrl = `${import.meta.env.VITE_API_URL}${fileUrl}`;
+      const response = await fetch(fullUrl, {
+        method: "GET",
+        credentials: "include", // 쿠키를 포함하여 요청
+      });
+
+      if (!response.ok) {
+        throw new Error("파일 다운로드에 실패했습니다.");
+      }
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+
+      // 리소스 정리
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(link);
+    } catch (error) {
+      console.error("파일 다운로드 오류:", error);
+      alert("파일 다운로드에 실패했습니다.");
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-5xl max-h-[85vh] overflow-y-auto min-w-[90vw]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center justify-between">
+            <span>멘토 지원 상세 정보</span>
+            {data && getStatusBadge(data.status)}
+          </DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-6 w-full" />
+            <Skeleton className="h-6 w-full" />
+            <Skeleton className="h-6 w-full" />
+          </div>
+        ) : data ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-2">
+            <div className="space-y-3">
+              <h3 className="text-sm font-semibold text-gray-500">직업 정보</h3>
+              <div className="border rounded-md p-5 space-y-3">
+                <div className="grid grid-cols-3">
+                  <span className="text-sm font-medium">직종</span>
+                  <span className="text-sm col-span-2">
+                    {data.modifiedFields.jobId?.after}
+                  </span>
+                </div>
+                <div className="grid grid-cols-3">
+                  <span className="text-sm font-medium">경력</span>
+                  <span className="text-sm col-span-2">
+                    {data.modifiedFields.career?.after}년
+                  </span>
+                </div>
+                <div className="grid grid-cols-3">
+                  <span className="text-sm font-medium">회사</span>
+                  <span className="text-sm col-span-2">
+                    {data.modifiedFields.currentCompany?.after}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="md:col-span-2 space-y-3">
+              <h3 className="text-sm font-semibold text-gray-500">자기소개</h3>
+              <div className="border rounded-md p-5">
+                <div className="rounded-md bg-background dark:bg-background">
+                  {data.modifiedFields.introduction?.after ? (
+                    <MDEditor.Markdown
+                      style={{
+                        backgroundColor: "transparent",
+                        fontSize: "14px",
+                      }}
+                      source={data.modifiedFields.introduction?.after}
+                    />
+                  ) : (
+                    <p className="text-sm text-gray-500">
+                      자기소개가 없습니다.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="md:col-span-2 space-y-3">
+              <h3 className="text-sm font-semibold text-gray-500">첨부파일</h3>
+              <div className="border rounded-md p-5">
+                {data.modifiedFields.attachments &&
+                data.modifiedFields.attachments.length > 0 ? (
+                  <div className="space-y-2">
+                    {data.modifiedFields.attachments.map(
+                      (attachment, index) => (
+                        <div
+                          key={index}
+                          className="flex items-center justify-between border-b pb-2 last:border-0"
+                        >
+                          <span className="text-sm">
+                            {attachment.fileName || "파일명 없음"}
+                          </span>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              handleDownload(
+                                attachment.fileUrl ?? "",
+                                attachment.fileName || `file-${index}`
+                              )
+                            }
+                          >
+                            다운로드
+                          </Button>
+                        </div>
+                      )
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">첨부파일이 없습니다.</p>
+                )}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="p-4 text-center text-gray-500">
+            정보를 불러오는데 실패했습니다.
+          </div>
+        )}
+
+        <DialogFooter className="mt-6">
+          <Button variant="outline" onClick={onClose}>
+            닫기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/service/src/widgets/chat-addon/chat-addon.tsx
+++ b/apps/service/src/widgets/chat-addon/chat-addon.tsx
@@ -190,7 +190,6 @@ function ChatRoomView({ chatRoom, onBack }: ChatRoomViewProps) {
   const handleSendMessage = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!newMessage.trim()) return;
-    console.log(`newMessage: ${newMessage}`);
 
     try {
       // WebSocket을 통해 메시지 전송

--- a/apps/service/src/widgets/chat-addon/hooks/use-websocket.ts
+++ b/apps/service/src/widgets/chat-addon/hooks/use-websocket.ts
@@ -54,14 +54,12 @@ export function useWebSocket(chatRoomId: string | null) {
       try {
         // 구독 해제
         if (subscriptionRef.current) {
-          console.log("구독 해제");
           subscriptionRef.current.unsubscribe();
           subscriptionRef.current = null;
         }
 
         // 연결 종료
         if (stompClientRef.current) {
-          console.log("연결 종료");
           stompClientRef.current.deactivate();
           stompClientRef.current = null;
         }
@@ -99,8 +97,7 @@ export function useWebSocket(chatRoomId: string | null) {
       });
 
       // 연결 성공 시 콜백
-      client.onConnect = (frame: IFrame) => {
-        console.log("WebSocket 연결 성공:", frame);
+      client.onConnect = () => {
         setStatus(WebSocketStatus.CONNECTED);
         setError(null);
 
@@ -111,7 +108,6 @@ export function useWebSocket(chatRoomId: string | null) {
             try {
               // 수신된 메시지 처리
               const data = JSON.parse(message.body) as WebSocketMessage;
-              console.log("메시지 수신:", data);
 
               // 새 메시지 생성
               const newMessage: ChatMessage = {

--- a/packages/api/src/fetchers/mentor/fetchers.ts
+++ b/packages/api/src/fetchers/mentor/fetchers.ts
@@ -134,7 +134,7 @@ export const requestUpdateMentorInfo = generateServiceFetcher<
 
 export const getMentorInfoModificationRequestList = generateServiceFetcher<
   { memberId: string },
-  { status: Status; page?: number; size?: number },
+  { status?: Status; page?: number; size?: number; proposalId?: number },
   void,
   {
     isSuccess: boolean;


### PR DESCRIPTION
## 요약

관리자 페이지의 멘토 정보 수정 요청에 대해서도 상세보기 기능을 제공합니다.

## 작업 내용

- [feat: 관리자 페이지에서 멘토 정보 수정 요청에 대한 상세보기 API 연동](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/32/commits/6312fc1f8fb83cb2cec5dac7dc1f16c5891b05f4)
- [refactor: 불필요 log 제거](https://github.com/prgrms-web-devcourse-final-project/WEB3_4_Tried-IT_FE/pull/32/commits/df40c1cbcb4f12300921f99174d39809bf03e6fd)
